### PR TITLE
Fix some 0.6.0 issues and update librdkafka to 2.2.0

### DIFF
--- a/src/CsharpClient/QuixStreams.IntegrationTestBase/QuixStreams.IntegrationTestBase.csproj
+++ b/src/CsharpClient/QuixStreams.IntegrationTestBase/QuixStreams.IntegrationTestBase.csproj
@@ -7,7 +7,7 @@
 
 
     <ItemGroup>
-        <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
+        <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
         <PackageReference Include="Ductus.FluentDocker" Version="2.10.57" />
     </ItemGroup>
 

--- a/src/CsharpClient/QuixStreams.Kafka/KafkaProducer.cs
+++ b/src/CsharpClient/QuixStreams.Kafka/KafkaProducer.cs
@@ -27,7 +27,8 @@ namespace QuixStreams.Kafka
         private bool checkBrokerStateBeforeSend = false;
         private bool logOnNextBrokerStateUp = false;
         private bool disableKafkaLogsByBrokerLogWorkaround = false; // if enabled, no actual kafka logs should be shown
-
+        private string lastReportedBrokerDownMessage = string.Empty;
+        
         /// <summary>
         /// Due to differing framing overhead between protocol versions the producer is unable
         /// to reliably enforce a strict max message limit at produce time.
@@ -117,7 +118,12 @@ namespace QuixStreams.Kafka
             
             try
             {
-                using (var adminClient = new AdminClientBuilder(this.config).Build())
+                void NullLoggerForAdminLogs(IAdminClient adminClient, LogMessage logMessage)
+                {
+                    // Log nothing
+                }
+                
+                using (var adminClient = new AdminClientBuilder(this.config).SetLogHandler(NullLoggerForAdminLogs).Build())
                 {
                     var maxBrokerMessageBytesNumeric = int.MaxValue;
                     try
@@ -224,6 +230,8 @@ namespace QuixStreams.Kafka
             lock (this.openLock)
             {
                 if (this.producer != null) return;
+                lastReportedBrokerDownMessage = string.Empty;
+                checkBrokerStateBeforeSend = false;
 
                 this.producer = new ProducerBuilder<byte[], byte[]>(this.config)
                     .SetErrorHandler(this.ErrorHandler)
@@ -305,8 +313,16 @@ namespace QuixStreams.Kafka
 
             if (ex.Message.Contains("brokers are down"))
             {
-                checkBrokerStateBeforeSend = true;
-                this.logger.LogDebug("[{0}] {1}, but delaying reporting until next message, in case reconnect happens before.", this.configId, ex.Message); // Excessive error reporting
+                if (!checkBrokerStateBeforeSend ||
+                    ex.Message != lastReportedBrokerDownMessage)
+                {
+                    checkBrokerStateBeforeSend = true;
+                    lastReportedBrokerDownMessage = ex.Message;
+                    this.logger.LogDebug(
+                        "[{0}] {1}, but delaying reporting until next message, in case reconnect happens before.",
+                        this.configId, ex.Message); // Excessive error reporting
+                }
+
                 return;
             }
             
@@ -423,7 +439,7 @@ namespace QuixStreams.Kafka
                     }
                     else
                     {
-                        this.logger.LogDebug("[{0}] {1}/{2} brokers are up (after all being marked down)", this.configId, upBrokerCount, this.brokerStates.Count);
+                        this.logger.LogDebug("[{0}] At least {1}/{2} brokers are up (after all being marked down).", this.configId, upBrokerCount, this.brokerStates.Count);
                     }
                 } 
                 do

--- a/src/CsharpClient/QuixStreams.Kafka/QuixStreams.Kafka.csproj
+++ b/src/CsharpClient/QuixStreams.Kafka/QuixStreams.Kafka.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.9.2" />
+    <PackageReference Include="Confluent.Kafka" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />


### PR DESCRIPTION
- Consumer should complete Open on partition assign on top of wake-up event, which is not always a guarantee without message to consume or when topic and partition is auto-created.
- Fix unnecessary logs for producer when using admin client
- Kafka producer now includes changes from 5b2472, 53a3b6
- Update librdkafka to 2.2.0