### PR TITLE
Async and interface suggestions.

### DIFF
--- a/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using QuixStreams.Kafka.Transport;
-using QuixStreams.Kafka.Transport.SerDes;
 using QuixStreams.Kafka.Transport.Tests.Helpers;
 using QuixStreams.Streaming.Raw;
 using QuixStreams.Streaming.Utils;
@@ -104,6 +103,30 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
         ITopicProducer IQuixStreamingClient.GetTopicProducer(string topicIdOrName)
         {
             return GetTopicProducer(topicIdOrName);
+        }
+
+        Task<ITopicConsumer> IQuixStreamingClientAsync.GetTopicConsumerAsync(
+            string topicIdOrName,
+            string consumerGroup,
+            CommitOptions options,
+            AutoOffsetReset autoOffset)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetTopicConsumer(topicIdOrName, consumerGroup, options, autoOffset));
+        }
+
+        Task<IRawTopicConsumer> IQuixStreamingClientAsync.GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup, AutoOffsetReset? autoOffset)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicConsumer(topicIdOrName, consumerGroup, autoOffset));
+        }
+
+        Task<IRawTopicProducer> IQuixStreamingClientAsync.GetRawTopicProducerAsync(string topicIdOrName)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicProducer(topicIdOrName));
+        }
+
+        Task<ITopicProducer> IQuixStreamingClientAsync.GetTopicProducerAsync(string topicIdOrName)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetTopicProducer(topicIdOrName));
         }
     }
 }

--- a/src/QuixStreams.Streaming.UnitTests/Models/LeadingEdgeBufferShould.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Models/LeadingEdgeBufferShould.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using FluentAssertions;
 using NSubstitute;
 using Quix.TestBase.Extensions;
-using QuixStreams;
 using QuixStreams.Streaming.Models;
+using QuixStreams.Streaming.Models.StreamProducer;
 using QuixStreams.Telemetry.Models;
 using QuixStreams.Telemetry.Models.Utility;
 using Xunit;
@@ -16,7 +16,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
     {
         public LeadingEdgeBufferShould(ITestOutputHelper helper)
         {
-            QuixStreams.Logging.Factory = helper.CreateLoggerFactory();
+            Logging.Factory = helper.CreateLoggerFactory();
         }
         
         [Fact]
@@ -27,7 +27,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(5000);
             
@@ -58,7 +58,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             
@@ -91,7 +91,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             
@@ -140,7 +140,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             
@@ -210,7 +210,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch);
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             
@@ -244,7 +244,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var offsetTs = TimeSpan.FromSeconds(1);
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch + offsetTs);
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             
@@ -277,7 +277,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var offsetTs = TimeSpan.FromSeconds(1);
             streamProducer.Epoch.Returns(TimeExtensions.UnixEpoch.AddTicks(offsetTs.ToNanoseconds() * 10000 / 1000)); // this should be totally ignored
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeBuffer(1000);
             buffer.Epoch = (int)(offsetTs.TotalMilliseconds * 1e6); // this should not be ignored

--- a/src/QuixStreams.Streaming.UnitTests/Models/LeadingEdgeTimeBufferShould.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Models/LeadingEdgeTimeBufferShould.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using FluentAssertions;
 using NSubstitute;
 using Quix.TestBase.Extensions;
-using QuixStreams;
 using QuixStreams.Streaming.Models;
+using QuixStreams.Streaming.Models.StreamProducer;
 using QuixStreams.Telemetry.Models;
 using QuixStreams.Telemetry.Models.Utility;
 using Xunit;
@@ -16,7 +16,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
     {
         public LeadingEdgeTimeBufferShould(ITestOutputHelper helper)
         {
-            QuixStreams.Logging.Factory = helper.CreateLoggerFactory();
+            Logging.Factory = helper.CreateLoggerFactory();
         }
         
         [Fact]
@@ -27,7 +27,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(DateTime.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(5000);
             
@@ -58,7 +58,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(DateTime.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             
@@ -91,7 +91,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(DateTime.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             
@@ -140,7 +140,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(DateTime.UnixEpoch);
 
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             
@@ -211,7 +211,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var streamProducer = Substitute.For<IStreamProducerInternal>();
             streamProducer.Epoch.Returns(DateTime.UnixEpoch);
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             
@@ -245,7 +245,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var offsetTs = TimeSpan.FromSeconds(1);
             streamProducer.Epoch.Returns(DateTime.UnixEpoch + offsetTs);
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             
@@ -278,7 +278,7 @@ namespace QuixStreams.Streaming.UnitTests.Models
             var offsetTs = TimeSpan.FromSeconds(1);
             streamProducer.Epoch.Returns(DateTime.UnixEpoch.AddTicks(offsetTs.ToNanoseconds() * 10000 / 1000)); // this should be totally ignored
             
-            var timeseriesProducer = new QuixStreams.Streaming.Models.StreamProducer.StreamTimeseriesProducer(topicProducer, streamProducer);
+            var timeseriesProducer = new StreamTimeseriesProducer(topicProducer, streamProducer);
 
             var buffer = timeseriesProducer.CreateLeadingEdgeTimeBuffer(1000);
             buffer.Epoch = (int)(offsetTs.TotalMilliseconds * 1e6); // this should not be ignored

--- a/src/QuixStreams.Streaming/IStreamConsumer.cs
+++ b/src/QuixStreams.Streaming/IStreamConsumer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using QuixStreams.Streaming.Models;
 using QuixStreams.Streaming.Models.StreamConsumer;
 using QuixStreams.Streaming.States;
@@ -25,17 +25,17 @@ namespace QuixStreams.Streaming
         /// <summary>
         /// Gets the consumer for accessing the properties and metadata of the stream.
         /// </summary>
-        StreamPropertiesConsumer Properties { get; }
+        IStreamPropertiesConsumer Properties { get; }
 
         /// <summary>
         /// Gets the consumer for accessing timeseries related information of the stream such as parameter definitions and values.
         /// </summary>
-        StreamTimeseriesConsumer Timeseries { get; }
+        IStreamTimeseriesConsumer Timeseries { get; }
 
         /// <summary>
         /// Gets the consumer for accessing event related information of the stream such as event definitions and values.
         /// </summary>
-        StreamEventsConsumer Events { get; }
+        IStreamEventsConsumer Events { get; }
 
         /// <summary>
         /// Event raised when a stream package has been received.

--- a/src/QuixStreams.Streaming/IStreamProducer.cs
+++ b/src/QuixStreams.Streaming/IStreamProducer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using QuixStreams.Streaming.Models.StreamProducer;
 
 namespace QuixStreams.Streaming
@@ -22,17 +22,17 @@ namespace QuixStreams.Streaming
         /// <summary>
         /// Properties of the stream. The changes will automatically be sent after a slight delay
         /// </summary>
-        StreamPropertiesProducer Properties { get; }
+        IStreamPropertiesProducer Properties { get; }
 
         /// <summary>
-        /// Gets the producer for publishing timeseries related information of the stream such as parameter definitions and values 
+        /// Gets the producer for publishing timeseries related information of the stream such as parameter definitions and values
         /// </summary>
-        StreamTimeseriesProducer Timeseries { get; }
+        IStreamTimeseriesProducer Timeseries { get; }
 
         /// <summary>
-        /// Gets the producer for publishing event related information of the stream such as event definitions and values  
+        /// Gets the producer for publishing event related information of the stream such as event definitions and values
         /// </summary>
-        StreamEventsProducer Events { get; }
+        IStreamEventsProducer Events { get; }
 
         /// <summary>
         /// Flush the pending data to stream.  

--- a/src/QuixStreams.Streaming/Models/LeadingEdgeBuffer.cs
+++ b/src/QuixStreams.Streaming/Models/LeadingEdgeBuffer.cs
@@ -10,13 +10,12 @@ namespace QuixStreams.Streaming.Models
     /// </summary>
     public class LeadingEdgeBuffer
     {
-        
         /// <summary>
         /// Sorted dictionary of rows in the buffer
         /// </summary>
         private readonly SortedDictionary<LeadingEdgeRowKey, LeadingEdgeRow> rows;
 
-        private readonly StreamTimeseriesProducer producer;
+        private readonly IStreamTimeseriesProducer producer;
         private readonly long leadingEdgeDelayInNanoseconds;
 
         private long leadingEdgeInNanoseconds = long.MinValue;
@@ -42,7 +41,7 @@ namespace QuixStreams.Streaming.Models
         /// </summary>
         /// <param name="producer">Instance of <see cref="StreamTimeseriesProducer"/></param>
         /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
-        internal LeadingEdgeBuffer(StreamTimeseriesProducer producer, int leadingEdgeDelayMs)
+        internal LeadingEdgeBuffer(IStreamTimeseriesProducer producer, int leadingEdgeDelayMs)
         {
             this.producer = producer;
             this.leadingEdgeDelayInNanoseconds = leadingEdgeDelayMs * (long)1e6;

--- a/src/QuixStreams.Streaming/Models/LeadingEdgeTimeBuffer.cs
+++ b/src/QuixStreams.Streaming/Models/LeadingEdgeTimeBuffer.cs
@@ -9,13 +9,12 @@ namespace QuixStreams.Streaming.Models
     /// </summary>
     public class LeadingEdgeTimeBuffer
     {
-        
         /// <summary>
         /// Sorted dictionary of rows in the buffer
         /// </summary>
         private readonly SortedDictionary<long, LeadingEdgeTimeRow> rows;
 
-        private readonly StreamTimeseriesProducer producer;
+        private readonly IStreamTimeseriesProducer producer;
         private readonly long leadingEdgeDelayInNanoseconds;
 
         private long leadingEdgeInNanoseconds = long.MinValue;
@@ -41,13 +40,12 @@ namespace QuixStreams.Streaming.Models
         /// </summary>
         /// <param name="producer">Instance of <see cref="StreamTimeseriesProducer"/></param>
         /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
-        internal LeadingEdgeTimeBuffer(StreamTimeseriesProducer producer, int leadingEdgeDelayMs)
+        internal LeadingEdgeTimeBuffer(IStreamTimeseriesProducer producer, int leadingEdgeDelayMs)
         {
             this.producer = producer;
             this.leadingEdgeDelayInNanoseconds = leadingEdgeDelayMs * (long)1e6;
             this.rows = new SortedDictionary<long, LeadingEdgeTimeRow>();
         }
-
 
         /// <summary>
         /// Gets an already buffered row based on timestamp and tags that can be modified or creates a new one if it doesn't exist.

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamEventsConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamEventsConsumer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using QuixStreams.Telemetry.Models;
+
+namespace QuixStreams.Streaming.Models.StreamConsumer
+{
+    /// <summary>
+    /// Interface for consumer of event streams, which raises <see cref="EventData"/> and <see cref="EventDefinitions"/> related messages
+    /// </summary>
+    public interface IStreamEventsConsumer : IDisposable
+    {
+        /// <summary>
+        /// Raised when an events data package is received for the stream
+        /// </summary>
+        event EventHandler<EventDataReadEventArgs> OnDataReceived;
+
+        /// <summary>
+        /// Raised when the event definitions have changed for the stream.
+        /// See <see cref="StreamEventsConsumer.Definitions"/> for the latest set of event definitions
+        /// </summary>
+        event EventHandler<EventDefinitionsChangedEventArgs> OnDefinitionsChanged;
+
+        /// <summary>
+        /// Gets the latest set of event definitions
+        /// </summary>
+        IList<EventDefinition> Definitions { get; }
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamPropertiesConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamPropertiesConsumer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace QuixStreams.Streaming.Models.StreamConsumer
+{
+    /// <summary>
+    /// Represents properties and metadata of the stream.
+    /// All changes to these properties are automatically populated to this class.
+    /// </summary>
+    public interface IStreamPropertiesConsumer : IDisposable
+    {
+        /// <summary>
+        /// Raised when the stream properties change
+        /// </summary>
+        event EventHandler<StreamPropertiesChangedEventArgs> OnChanged;
+
+        /// <summary>
+        /// Gets the name of the stream
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Gets the location of the stream
+        /// </summary>
+        string Location { get; }
+
+        /// <summary>
+        /// Gets the datetime of the recording
+        /// </summary>
+        DateTime? TimeOfRecording { get; }
+
+        /// <summary>
+        /// Gets the metadata of the stream
+        /// </summary>
+        Dictionary<string, string> Metadata { get; }
+
+        /// <summary>
+        /// Gets the list of Stream IDs for the parent streams
+        /// </summary>
+        List<string> Parents { get; }
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamTimeseriesConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/IStreamTimeseriesConsumer.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using QuixStreams.Telemetry.Models;
+
+namespace QuixStreams.Streaming.Models.StreamConsumer
+{
+    /// <summary>
+    /// Consumer for streams, which raises <see cref="TimeseriesData"/> and <see cref="ParameterDefinitions"/> related messages
+    /// </summary>
+    public interface IStreamTimeseriesConsumer : IDisposable
+    {
+        /// <summary>
+        /// Creates a new buffer for reading data
+        /// </summary>
+        /// <param name="bufferConfiguration">An optional TimeseriesBufferConfiguration</param>
+        /// <param name="parametersFilter">Zero or more parameter identifiers to filter as a whitelist. If provided, only those parameters will be available through this buffer</param>
+        /// <returns><see cref="TimeseriesBufferConsumer"/> which will raise OnDataReceived event when new data is consumed</returns>
+        TimeseriesBufferConsumer CreateBuffer(TimeseriesBufferConfiguration bufferConfiguration = null, params string[] parametersFilter);
+
+        /// <summary>
+        /// Creates a new buffer for reading data
+        /// </summary>
+        /// <param name="parametersFilter">Zero or more parameter identifiers to filter as a whitelist. If provided, only those parameters will be available through this buffer</param>
+        /// <returns><see cref="TimeseriesBufferConsumer"/> which will raise OnDataReceived event when new data is consumed</returns>
+        TimeseriesBufferConsumer CreateBuffer(params string[] parametersFilter);
+
+        /// <summary>
+        /// Raised when the parameter definitions have changed for the stream.
+        /// See <see cref="StreamTimeseriesConsumer.Definitions"/> for the latest set of parameter definitions
+        /// </summary>
+        event EventHandler<ParameterDefinitionsChangedEventArgs> OnDefinitionsChanged;
+
+        /// <summary>
+        /// Event raised when data is received (without buffering)
+        /// This event does not use Buffers, and data will be raised as they arrive without any processing.
+        /// </summary>
+        event EventHandler<TimeseriesDataReadEventArgs> OnDataReceived;
+
+        /// <summary>
+        /// Event raised when data is received (without buffering) in raw transport format
+        /// This event does not use Buffers, and data will be raised as they arrive without any processing.
+        /// </summary>
+        event EventHandler<TimeseriesDataRawReadEventArgs> OnRawReceived;
+
+        /// <summary>
+        /// Gets the latest set of parameter definitions
+        /// </summary>
+        List<ParameterDefinition> Definitions { get; }
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/StreamEventsConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/StreamEventsConsumer.cs
@@ -8,7 +8,7 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
     /// <summary>
     /// Consumer for streams, which raises <see cref="EventData"/> and <see cref="EventDefinitions"/> related messages
     /// </summary>
-    public class StreamEventsConsumer : IDisposable
+    public class StreamEventsConsumer : IStreamEventsConsumer
     {
         private readonly ITopicConsumer topicConsumer;
         private readonly IStreamConsumerInternal streamConsumer;
@@ -42,20 +42,13 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
             this.OnDefinitionsChanged?.Invoke(this, new EventDefinitionsChangedEventArgs(this.topicConsumer, this.streamConsumer));
         }
 
-        /// <summary>
-        /// Raised when an events data package is received for the stream
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<EventDataReadEventArgs> OnDataReceived;
 
-        /// <summary>
-        /// Raised when the event definitions have changed for the stream.
-        /// See <see cref="Definitions"/> for the latest set of event definitions
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<EventDefinitionsChangedEventArgs> OnDefinitionsChanged;
 
-        /// <summary>
-        /// Gets the latest set of event definitions
-        /// </summary>
+        /// <inheritdoc/>
         public IList<EventDefinition> Definitions { get; private set; } 
 
         private void LoadFromTelemetryDefinitions(QuixStreams.Telemetry.Models.EventDefinitions definitions)

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/StreamPropertiesConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/StreamPropertiesConsumer.cs
@@ -8,7 +8,7 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
     /// Represents properties and metadata of the stream.
     /// All changes to these properties are automatically populated to this class.
     /// </summary>
-    public class StreamPropertiesConsumer : IDisposable
+    public class StreamPropertiesConsumer : IStreamPropertiesConsumer
     {
         private readonly ITopicConsumer topicConsumer;
         private readonly IStreamConsumerInternal streamConsumer;
@@ -40,34 +40,22 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
             this.OnChanged?.Invoke(this, new StreamPropertiesChangedEventArgs(this.topicConsumer, sender));
         }
 
-        /// <summary>
-        /// Raised when the stream properties change
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<StreamPropertiesChangedEventArgs> OnChanged;
 
-        /// <summary>
-        /// Gets the name of the stream
-        /// </summary>
+        /// <inheritdoc/>
         public string Name { get; private set; }
 
-        /// <summary>
-        /// Gets the location of the stream
-        /// </summary>
+        /// <inheritdoc/>
         public string Location { get; private set; }
 
-        /// <summary>
-        /// Gets the datetime of the recording
-        /// </summary>
+        /// <inheritdoc/>
         public DateTime? TimeOfRecording { get; private set; }
 
-        /// <summary>
-        /// Gets the metadata of the stream
-        /// </summary>
+        /// <inheritdoc/>
         public Dictionary<string, string> Metadata { get; private set; }
 
-        /// <summary>
-        /// Gets the list of Stream IDs for the parent streams
-        /// </summary>
+        /// <inheritdoc/>
         public List<string> Parents { get; private set; }
 
         /// <inheritdoc/>

--- a/src/QuixStreams.Streaming/Models/StreamConsumer/StreamTimeseriesConsumer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamConsumer/StreamTimeseriesConsumer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using QuixStreams.Telemetry.Models;
@@ -8,7 +8,7 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
     /// <summary>
     /// Consumer for streams, which raises <see cref="TimeseriesData"/> and <see cref="ParameterDefinitions"/> related messages
     /// </summary>
-    public class StreamTimeseriesConsumer : IDisposable
+    public class StreamTimeseriesConsumer : IStreamTimeseriesConsumer
     {
         private readonly ITopicConsumer topicConsumer;
         private readonly IStreamConsumerInternal streamConsumer;
@@ -36,12 +36,7 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
             this.OnDefinitionsChanged?.Invoke(this.streamConsumer, new ParameterDefinitionsChangedEventArgs(this.topicConsumer, this.streamConsumer));
         }
 
-        /// <summary>
-        /// Creates a new buffer for reading data
-        /// </summary>
-        /// <param name="bufferConfiguration">An optional TimeseriesBufferConfiguration</param>
-        /// <param name="parametersFilter">Zero or more parameter identifiers to filter as a whitelist. If provided, only those parameters will be available through this buffer</param>
-        /// <returns><see cref="TimeseriesBufferConsumer"/> which will raise OnDataReceived event when new data is consumed</returns>
+        /// <inheritdoc/>
         public TimeseriesBufferConsumer CreateBuffer(TimeseriesBufferConfiguration bufferConfiguration = null, params string[] parametersFilter)
         {
             var buffer = new TimeseriesBufferConsumer(this.topicConsumer, this.streamConsumer, bufferConfiguration, parametersFilter);
@@ -50,11 +45,7 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
             return buffer;
         }
 
-        /// <summary>
-        /// Creates a new buffer for reading data
-        /// </summary>
-        /// <param name="parametersFilter">Zero or more parameter identifiers to filter as a whitelist. If provided, only those parameters will be available through this buffer</param>
-        /// <returns><see cref="TimeseriesBufferConsumer"/> which will raise OnDataReceived event when new data is consumed</returns>
+        /// <inheritdoc/>
         public TimeseriesBufferConsumer CreateBuffer(params string[] parametersFilter)
         {
             var buffer = new TimeseriesBufferConsumer(this.topicConsumer, this.streamConsumer, null, parametersFilter);
@@ -63,27 +54,16 @@ namespace QuixStreams.Streaming.Models.StreamConsumer
             return buffer;
         }
 
-        /// <summary>
-        /// Raised when the parameter definitions have changed for the stream.
-        /// See <see cref="Definitions"/> for the latest set of parameter definitions
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<ParameterDefinitionsChangedEventArgs> OnDefinitionsChanged;
 
-        /// <summary>
-        /// Event raised when data is received (without buffering)
-        /// This event does not use Buffers, and data will be raised as they arrive without any processing.
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<TimeseriesDataReadEventArgs> OnDataReceived;
 
-        /// <summary>
-        /// Event raised when data is received (without buffering) in raw transport format
-        /// This event does not use Buffers, and data will be raised as they arrive without any processing.
-        /// </summary>
+        /// <inheritdoc/>
         public event EventHandler<TimeseriesDataRawReadEventArgs> OnRawReceived;
 
-        /// <summary>
-        /// Gets the latest set of parameter definitions
-        /// </summary>
+        /// <inheritdoc/>
         public List<ParameterDefinition> Definitions { get; private set; } = new List<ParameterDefinition>();
 
         /// <summary>

--- a/src/QuixStreams.Streaming/Models/StreamProducer/IStreamEventsProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/IStreamEventsProducer.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using QuixStreams.Telemetry.Models;
+
+namespace QuixStreams.Streaming.Models.StreamProducer
+{
+    /// <summary>
+    /// Helper class for producing <see cref="EventDefinitions"/> and <see cref="EventData"/>
+    /// </summary>
+    public interface IStreamEventsProducer : IDisposable
+    {
+        /// <summary>
+        /// Default epoch used for Timestamp event values. Datetime added on top of all the Timestamps.
+        /// </summary>
+        DateTime Epoch { get; set; }
+
+        /// <summary>
+        /// Default Tags injected to all Event Values sent by the producer.
+        /// </summary>
+        Dictionary<string, string> DefaultTags { get; set; }
+
+        /// <summary>
+        /// Default Location of the events. Event definitions added with <see cref="AddDefinition"/> will be inserted at this location.
+        /// See <see cref="AddLocation"/> for adding definitions at a different location without changing default.
+        /// Example: "/Group1/SubGroup2"
+        /// </summary>
+        string DefaultLocation { get; set; }
+
+        /// <summary>
+        /// Starts adding a new set of event values at the given timestamp.
+        /// Note, <see cref="StreamEventsProducer.Epoch"/> is not used when invoking with <see cref="DateTime"/>
+        /// </summary>
+        /// <param name="dateTime">The datetime to use for adding new event values</param>
+        /// <returns>Event data builder to add event values at the provided time</returns>
+        EventDataBuilder AddTimestamp(DateTime dateTime);
+
+        /// <summary>
+        /// Starts adding a new set of event values at the given timestamp.
+        /// </summary>
+        /// <param name="timeSpan">The time since the default <see cref="StreamEventsProducer.Epoch"/> to add the event values at</param>
+        /// <returns>Event data builder to add event values at the provided time</returns>
+        EventDataBuilder AddTimestamp(TimeSpan timeSpan);
+
+        /// <summary>
+        /// Starts adding a new set of event values at the given timestamp.
+        /// </summary>
+        /// <param name="timeMilliseconds">The time in milliseconds since the default <see cref="StreamEventsProducer.Epoch"/> to add the event values at</param>
+        /// <returns>Event data builder to add event values at the provided time</returns>
+        EventDataBuilder AddTimestampMilliseconds(long timeMilliseconds);
+
+        /// <summary>
+        /// Starts adding a new set of event values at the given timestamp.
+        /// </summary>
+        /// <param name="timeNanoseconds">The time in nanoseconds since the default <see cref="StreamEventsProducer.Epoch"/> to add the event values at</param>
+        /// <returns>Event data builder to add event values at the provided time</returns>
+        EventDataBuilder AddTimestampNanoseconds(long timeNanoseconds);
+
+        /// <summary>
+        /// Adds a list of definitions to the <see cref="StreamEventsProducer"/>. Configure it with the builder methods.
+        /// </summary>
+        /// <param name="definitions">List of definitions</param>
+        void AddDefinitions(List<EventDefinition> definitions);
+
+        /// <summary>
+        /// Add new Event definition to define properties like Name or Level, among others.
+        /// </summary>
+        /// <param name="eventId">Event Id. This must match the event id you use to Event values</param>
+        /// <param name="name">Human friendly display name of the event</param>
+        /// <param name="description">Description of the event</param>
+        /// <returns>Event definition builder to define the event properties</returns>
+        EventDefinitionBuilder AddDefinition(string eventId, string name = null, string description = null);
+
+        /// <summary>
+        /// Adds a new Location in the event groups hierarchy.
+        /// </summary>
+        /// <param name="location">The group location</param>
+        EventDefinitionBuilder AddLocation(string location);
+
+        /// <summary>
+        /// Immediately writes the event definitions from the buffer without waiting for buffer condition to fulfill (200ms timeout)
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Publish an event into the stream.
+        /// </summary>
+        /// <param name="data">Event to publish</param>
+        void Publish(EventData data);
+
+        /// <summary>
+        /// Publish events into the stream.
+        /// </summary>
+        /// <param name="events">Events to publish</param>
+        void Publish(ICollection<EventData> events);
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamProducer/IStreamPropertiesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/IStreamPropertiesProducer.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.ObjectModel;
+
+namespace QuixStreams.Streaming.Models.StreamProducer
+{
+    /// <summary>
+    /// Represents properties and metadata of the stream.
+    /// All changes to these properties are automatically published to the underlying stream.
+    /// </summary>
+    public interface IStreamPropertiesProducer : IDisposable
+    {
+        /// <summary>
+        /// Name of the stream.
+        /// </summary>
+        string Name { get; set; }
+
+        /// <summary>
+        /// Specify location of the stream in data catalogue.
+        /// For example: /cars/ai/carA/.
+        /// </summary>
+        string Location { get; set; }
+
+        /// <summary>
+        /// Date Time of stream recording. Commonly set to Datetime.UtcNow.
+        /// </summary>
+        DateTime? TimeOfRecording { get; set; }
+
+        /// <summary>
+        /// Automatic flush interval of the properties metadata into the channel [ in milliseconds ]
+        /// </summary>
+        int FlushInterval { get; set; }
+
+        /// <summary>
+        /// Metadata of the stream.
+        /// </summary>
+        ObservableDictionary<string, string> Metadata { get; }
+
+        /// <summary>
+        /// List of Stream Ids of the Parent streams
+        /// </summary>
+        ObservableCollection<string> Parents { get; }
+
+        /// <summary>
+        /// Adds a parent stream.
+        /// </summary>
+        /// <param name="parentStreamId">Stream Id of the parent</param>
+        void AddParent(string parentStreamId);
+
+        /// <summary>
+        /// Removes a parent stream
+        /// </summary>
+        /// <param name="parentStreamId">Stream Id of the parent</param>
+        void RemoveParent(string parentStreamId);
+
+        /// <summary>
+        /// Immediately writes the properties yet to be sent instead of waiting for the flush timer (20ms)
+        /// </summary>
+        void Flush();
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamProducer/IStreamTimeseriesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/IStreamTimeseriesProducer.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace QuixStreams.Streaming.Models.StreamProducer
+{
+    /// <summary>
+    /// Helper class for producing <see cref="ParameterDefinition"/> and <see cref="TimeseriesData"/>
+    /// </summary>
+    public interface IStreamTimeseriesProducer : IDisposable
+    {
+        /// <summary>
+        /// Gets the buffer for producing timeseries data
+        /// </summary>
+        TimeseriesBufferProducer Buffer { get; }
+
+        /// <summary>
+        /// Default Location of the parameters. Parameter definitions added with <see cref="AddDefinition"/> will be inserted at this location.
+        /// See <see cref="AddLocation"/> for adding definitions at a different location without changing default.
+        /// Example: "/Group1/SubGroup2"
+        /// </summary>
+        string DefaultLocation { get; set; }
+
+        /// <summary>
+        /// Publish data to stream without any buffering
+        /// </summary>
+        /// <param name="data">Timeseries data to publish</param>
+        void Publish(TimeseriesData data);
+
+        /// <summary>
+        /// Publish data in TimeseriesDataRaw format without any buffering
+        /// </summary>
+        /// <param name="data">Timeseries data to publish</param>
+        void Publish(QuixStreams.Telemetry.Models.TimeseriesDataRaw data);
+
+        /// <summary>
+        /// Publish single timestamp to stream without any buffering
+        /// </summary>
+        /// <param name="timestamp">Timeseries timestamp to publish</param>
+        void Publish(TimeseriesDataTimestamp timestamp);
+
+        /// <summary>
+        /// Adds a list of definitions to the <see cref="StreamTimeseriesProducer"/>. Configure it with the builder methods.
+        /// </summary>
+        /// <param name="definitions">List of definitions</param>
+        void AddDefinitions(List<ParameterDefinition> definitions);
+
+        /// <summary>
+        /// Adds a new parameter definition to the <see cref="StreamTimeseriesProducer"/>. Configure it with the builder methods.
+        /// </summary>
+        /// <param name="parameterId">The id of the parameter. Must match the parameter id used to send data.</param>
+        /// <param name="name">The human friendly display name of the parameter</param>
+        /// <param name="description">The description of the parameter</param>
+        /// <returns>Parameter definition builder to define the parameter properties</returns>
+        ParameterDefinitionBuilder AddDefinition(string parameterId, string name = null, string description = null);
+
+        /// <summary>
+        /// Adds a new location in the parameters groups hierarchy
+        /// </summary>
+        /// <param name="location">The group location</param>
+        /// <returns>Parameter definition builder to define the parameters under the specified location</returns>
+        ParameterDefinitionBuilder AddLocation(string location);
+
+        /// <summary>
+        /// Immediately publish timeseries data and definitions from the buffer without waiting for buffer condition to fulfill for either
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Creates a new <see cref="LeadingEdgeBuffer"/> using this producer where tags form part of the row's key
+        /// and can't be modified after initial values
+        /// </summary>
+        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+        LeadingEdgeBuffer CreateLeadingEdgeBuffer(int leadingEdgeDelayMs);
+
+        /// <summary>
+        /// Creates a new <see cref="LeadingEdgeTimeBuffer"/> using this producer where tags do not form part of the row's key
+        /// and can be freely modified after initial values
+        /// </summary>
+        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+        LeadingEdgeTimeBuffer CreateLeadingEdgeTimeBuffer(int leadingEdgeDelayMs);
+    }
+}

--- a/src/QuixStreams.Streaming/Models/StreamProducer/IStreamTimeseriesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/IStreamTimeseriesProducer.cs
@@ -64,19 +64,5 @@ namespace QuixStreams.Streaming.Models.StreamProducer
         /// Immediately publish timeseries data and definitions from the buffer without waiting for buffer condition to fulfill for either
         /// </summary>
         void Flush();
-
-        /// <summary>
-        /// Creates a new <see cref="LeadingEdgeBuffer"/> using this producer where tags form part of the row's key
-        /// and can't be modified after initial values
-        /// </summary>
-        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
-        LeadingEdgeBuffer CreateLeadingEdgeBuffer(int leadingEdgeDelayMs);
-
-        /// <summary>
-        /// Creates a new <see cref="LeadingEdgeTimeBuffer"/> using this producer where tags do not form part of the row's key
-        /// and can be freely modified after initial values
-        /// </summary>
-        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
-        LeadingEdgeTimeBuffer CreateLeadingEdgeTimeBuffer(int leadingEdgeDelayMs);
     }
 }

--- a/src/QuixStreams.Streaming/Models/StreamProducer/StreamEventsProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/StreamEventsProducer.cs
@@ -1,9 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using QuixStreams;
 using QuixStreams.Streaming.Exceptions;
 using QuixStreams.Telemetry.Managers;
 using QuixStreams.Telemetry.Models;
@@ -14,7 +13,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
     /// <summary>
     /// Helper class for producing <see cref="EventDefinitions"/> and <see cref="EventData"/>
     /// </summary>
-    public class StreamEventsProducer : IDisposable
+    public class StreamEventsProducer : IStreamEventsProducer
     {
         private readonly ILogger logger = QuixStreams.Logging.CreateLogger<StreamEventsProducer>();
         private readonly IStreamProducerInternal streamProducer;
@@ -44,16 +43,10 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.DefaultLocation = "/";
         }
 
-        /// <summary>
-        /// Default Tags injected to all Event Values sent by the producer.
-        /// </summary>
+        /// <inheritdoc/>
         public Dictionary<string, string> DefaultTags { get; set; } = new Dictionary<string, string>();
 
-        /// <summary>
-        /// Default Location of the events. Event definitions added with <see cref="AddDefinition"/> will be inserted at this location.
-        /// See <see cref="AddLocation"/> for adding definitions at a different location without changing default.
-        /// Example: "/Group1/SubGroup2"
-        /// </summary>
+        /// <inheritdoc/>
         public string DefaultLocation
         {
             get
@@ -70,9 +63,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Default epoch used for Timestamp event values. Datetime added on top of all the Timestamps.
-        /// </summary>
+        /// <inheritdoc/>
         public DateTime Epoch
         {
             get
@@ -89,33 +80,16 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Starts adding a new set of event values at the given timestamp.
-        /// Note, <see cref="Epoch"/> is not used when invoking with <see cref="DateTime"/>
-        /// </summary>
-        /// <param name="dateTime">The datetime to use for adding new event values</param>
-        /// <returns>Event data builder to add event values at the provided time</returns>
+        /// <inheritdoc/>
         public EventDataBuilder AddTimestamp(DateTime dateTime) => this.AddTimestampNanoseconds(dateTime.ToUnixNanoseconds(), 0);
 
-        /// <summary>
-        /// Starts adding a new set of event values at the given timestamp.
-        /// </summary>
-        /// <param name="timeSpan">The time since the default <see cref="Epoch"/> to add the event values at</param>
-        /// <returns>Event data builder to add event values at the provided time</returns>
+        /// <inheritdoc/>
         public EventDataBuilder AddTimestamp(TimeSpan timeSpan) => this.AddTimestampNanoseconds(timeSpan.ToNanoseconds());
 
-        /// <summary>
-        /// Starts adding a new set of event values at the given timestamp.
-        /// </summary>
-        /// <param name="timeMilliseconds">The time in milliseconds since the default <see cref="Epoch"/> to add the event values at</param>
-        /// <returns>Event data builder to add event values at the provided time</returns>
+        /// <inheritdoc/>
         public EventDataBuilder AddTimestampMilliseconds(long timeMilliseconds) => this.AddTimestampNanoseconds(timeMilliseconds * (long) 1e6);
 
-        /// <summary>
-        /// Starts adding a new set of event values at the given timestamp.
-        /// </summary>
-        /// <param name="timeNanoseconds">The time in nanoseconds since the default <see cref="Epoch"/> to add the event values at</param>
-        /// <returns>Event data builder to add event values at the provided time</returns>
+        /// <inheritdoc/>
         public EventDataBuilder AddTimestampNanoseconds(long timeNanoseconds)
         {
             if (isDisposed)
@@ -134,10 +108,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             return new EventDataBuilder(this, epoch + timeNanoseconds);
         }
 
-        /// <summary>
-        /// Adds a list of definitions to the <see cref="StreamEventsProducer"/>. Configure it with the builder methods.
-        /// </summary>
-        /// <param name="definitions">List of definitions</param>
+        /// <inheritdoc/>
         public void AddDefinitions(List<EventDefinition> definitions)
         {
             if (isDisposed)
@@ -149,13 +120,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.ResetFlushDefinitionsTimer();
         }
 
-        /// <summary>
-        /// Add new Event definition to define properties like Name or Level, among others.
-        /// </summary>
-        /// <param name="eventId">Event Id. This must match the event id you use to Event values</param>
-        /// <param name="name">Human friendly display name of the event</param>
-        /// <param name="description">Description of the event</param>
-        /// <returns>Event definition builder to define the event properties</returns>
+        /// <inheritdoc/>
         public EventDefinitionBuilder AddDefinition(string eventId, string name = null, string description = null)
         {
             if (isDisposed)
@@ -169,10 +134,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             return builder;
         }
 
-        /// <summary>
-        /// Adds a new Location in the event groups hierarchy.
-        /// </summary>
-        /// <param name="location">The group location</param>
+        /// <inheritdoc/>
         public EventDefinitionBuilder AddLocation(string location)
         {
             if (isDisposed)
@@ -206,10 +168,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             return eventDefinition;
         }
 
-
-        /// <summary>
-        /// Immediately writes the event definitions from the buffer without waiting for buffer condition to fulfill (200ms timeout)
-        /// </summary>
+        /// <inheritdoc/>
         public void Flush()
         {
             this.Flush(false);
@@ -234,10 +193,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Publish an event into the stream.
-        /// </summary>
-        /// <param name="data">Event to publish</param>
+        /// <inheritdoc/>
         public void Publish(EventData data)
         {
             if (isDisposed)
@@ -262,10 +218,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.logger.Log(LogLevel.Trace, "event '{0}' sent.", data.Id);
         }
 
-        /// <summary>
-        /// Publish events into the stream.
-        /// </summary>
-        /// <param name="events">Events to publish</param>
+        /// <inheritdoc/>
         public void Publish(ICollection<EventData> events)
         {
             if (isDisposed)
@@ -335,9 +288,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.streamProducer.Publish(definitions);
         }
 
-        /// <summary>
-        /// Flushes internal buffers and disposes
-        /// </summary>
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (this.isDisposed) return;

--- a/src/QuixStreams.Streaming/Models/StreamProducer/StreamPropertiesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/StreamPropertiesProducer.cs
@@ -13,7 +13,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
     /// Represents properties and metadata of the stream.
     /// All changes to these properties are automatically published to the underlying stream.
     /// </summary>
-    public class StreamPropertiesProducer : IDisposable
+    public class StreamPropertiesProducer : IStreamPropertiesProducer
     {
         private readonly IStreamProducerInternal streamProducer;
         private string name;
@@ -31,9 +31,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
         private int heartbeatRebroadcastFlushInterval = 30*1000;
         private readonly ILogger<StreamTimeseriesProducer> logger = QuixStreams.Logging.CreateLogger<StreamTimeseriesProducer>();
 
-        /// <summary>
-        /// Automatic flush interval of the properties metadata into the channel [ in milliseconds ]
-        /// </summary>
+        /// <inheritdoc/>
         public int FlushInterval
         {
             get
@@ -98,9 +96,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }, null, Timeout.Infinite, Timeout.Infinite);
         }
 
-        /// <summary>
-        /// Name of the stream.
-        /// </summary>
+        /// <inheritdoc/>
         public string Name
         {
             get => name; set
@@ -114,10 +110,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Specify location of the stream in data catalogue. 
-        /// For example: /cars/ai/carA/.
-        /// </summary>
+        /// <inheritdoc/>
         public string Location
         {
             get => location; set
@@ -131,9 +124,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Date Time of stream recording. Commonly set to Datetime.UtcNow.
-        /// </summary>
+        /// <inheritdoc/>
         public DateTime? TimeOfRecording
         {
             get => timeOfRecording; set
@@ -156,20 +147,13 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Metadata of the stream.
-        /// </summary>
+        /// <inheritdoc/>
         public ObservableDictionary<string, string> Metadata { get; }
 
-        /// <summary>
-        /// List of Stream Ids of the Parent streams
-        /// </summary>
+        /// <inheritdoc/>
         public ObservableCollection<string> Parents { get; }
 
-        /// <summary>
-        /// Adds a parent stream.
-        /// </summary>
-        /// <param name="parentStreamId">Stream Id of the parent</param>
+        /// <inheritdoc/>
         public void AddParent(string parentStreamId)
         {
             if (isDisposed)
@@ -180,10 +164,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.Parents.Add(parentStreamId);
         }
 
-        /// <summary>
-        /// Removes a parent stream
-        /// </summary>
-        /// <param name="parentStreamId">Stream Id of the parent</param>
+        /// <inheritdoc/>
         public void RemoveParent(string parentStreamId)
         {
             if (isDisposed)
@@ -194,9 +175,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.Parents.Remove(parentStreamId);
         }
 
-        /// <summary>
-        /// Immediately writes the properties yet to be sent instead of waiting for the flush timer (20ms)
-        /// </summary>
+        /// <inheritdoc/>
         public void Flush()
         {
             this.Flush(false);
@@ -288,9 +267,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.flushTimer.Change(PropertyChangedFlushInterval, Timeout.Infinite);
         }
 
-        /// <summary>
-        /// Flushes internal buffers and disposes
-        /// </summary>
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (this.isDisposed) return;

--- a/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducer.cs
@@ -205,18 +205,6 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.Flush(false);
         }
 
-        /// <inheritdoc/>
-        public LeadingEdgeBuffer CreateLeadingEdgeBuffer(int leadingEdgeDelayMs)
-        {
-            return new LeadingEdgeBuffer(this, leadingEdgeDelayMs);
-        }
-
-        /// <inheritdoc/>
-        public LeadingEdgeTimeBuffer CreateLeadingEdgeTimeBuffer(int leadingEdgeDelayMs)
-        {
-            return new LeadingEdgeTimeBuffer(this, leadingEdgeDelayMs);
-        }
-
         private void Flush(bool force)
         {
             if (!force && isDisposed)

--- a/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducer.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducer.cs
@@ -12,7 +12,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
     /// <summary>
     /// Helper class for producing <see cref="ParameterDefinition"/> and <see cref="TimeseriesData"/>
     /// </summary>
-    public class StreamTimeseriesProducer : IDisposable
+    public class StreamTimeseriesProducer : IStreamTimeseriesProducer
     {
         private readonly IStreamProducerInternal streamProducer;
 
@@ -45,15 +45,10 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.DefaultLocation = "/";
         }
 
-        /// <summary>
-        /// Gets the buffer for producing timeseries data
-        /// </summary>
+        /// <inheritdoc/>
         public TimeseriesBufferProducer Buffer { get;  }
 
-        /// <summary>
-        /// Publish data to stream without any buffering
-        /// </summary>
-        /// <param name="data">Timeseries data to publish</param>
+        /// <inheritdoc/>
         public void Publish(TimeseriesData data)
         {
             if (isDisposed)
@@ -75,10 +70,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.streamProducer.Publish(data.ConvertToTimeseriesDataRaw());
         }
         
-        /// <summary>
-        /// Publish data in TimeseriesDataRaw format without any buffering
-        /// </summary>
-        /// <param name="data">Timeseries data to publish</param>
+        /// <inheritdoc/>
         public void Publish(QuixStreams.Telemetry.Models.TimeseriesDataRaw data)
         {
             if (isDisposed)
@@ -113,10 +105,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.streamProducer.Publish(newData);
         }
 
-        /// <summary>
-        /// Publish single timestamp to stream without any buffering
-        /// </summary>
-        /// <param name="timestamp">Timeseries timestamp to publish</param>
+        /// <inheritdoc/>
         public void Publish(TimeseriesDataTimestamp timestamp)
         {
             if (isDisposed)
@@ -133,11 +122,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.streamProducer.Publish(timestamp.ConvertToTimeseriesDataRaw());
         }
         
-        /// <summary>
-        /// Default Location of the parameters. Parameter definitions added with <see cref="AddDefinition"/> will be inserted at this location.
-        /// See <see cref="AddLocation"/> for adding definitions at a different location without changing default.
-        /// Example: "/Group1/SubGroup2"
-        /// </summary>
+        /// <inheritdoc/>
         public string DefaultLocation
         {
             get
@@ -154,10 +139,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             }
         }
 
-        /// <summary>
-        /// Adds a list of definitions to the <see cref="StreamTimeseriesProducer"/>. Configure it with the builder methods.
-        /// </summary>
-        /// <param name="definitions">List of definitions</param>
+        /// <inheritdoc/>
         public void AddDefinitions(List<ParameterDefinition> definitions)
         {
             if (isDisposed)
@@ -169,13 +151,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.ResetFlushDefinitionsTimer();
         }
 
-        /// <summary>
-        /// Adds a new parameter definition to the <see cref="StreamTimeseriesProducer"/>. Configure it with the builder methods.
-        /// </summary>
-        /// <param name="parameterId">The id of the parameter. Must match the parameter id used to send data.</param>
-        /// <param name="name">The human friendly display name of the parameter</param>
-        /// <param name="description">The description of the parameter</param>
-        /// <returns>Parameter definition builder to define the parameter properties</returns>
+        /// <inheritdoc/>
         public ParameterDefinitionBuilder AddDefinition(string parameterId, string name = null, string description = null)
         {
             if (isDisposed)
@@ -189,11 +165,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             return builder;
         }
 
-        /// <summary>
-        /// Adds a new location in the parameters groups hierarchy
-        /// </summary>
-        /// <param name="location">The group location</param>
-        /// <returns>Parameter definition builder to define the parameters under the specified location</returns>
+        /// <inheritdoc/>
         public ParameterDefinitionBuilder AddLocation(string location)
         {
             if (isDisposed)
@@ -227,29 +199,19 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             return parameterDefinition;
         }
 
-        /// <summary>
-        /// Immediately publish timeseries data and definitions from the buffer without waiting for buffer condition to fulfill for either
-        /// </summary>
+        /// <inheritdoc/>
         public void Flush()
         {
             this.Flush(false);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="LeadingEdgeBuffer"/> using this producer where tags form part of the row's key
-        /// and can't be modified after initial values
-        /// </summary>
-        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+        /// <inheritdoc/>
         public LeadingEdgeBuffer CreateLeadingEdgeBuffer(int leadingEdgeDelayMs)
         {
             return new LeadingEdgeBuffer(this, leadingEdgeDelayMs);
         }
-        
-        /// <summary>
-        /// Creates a new <see cref="LeadingEdgeTimeBuffer"/> using this producer where tags do not form part of the row's key
-        /// and can be freely modified after initial values
-        /// </summary>
-        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+
+        /// <inheritdoc/>
         public LeadingEdgeTimeBuffer CreateLeadingEdgeTimeBuffer(int leadingEdgeDelayMs)
         {
             return new LeadingEdgeTimeBuffer(this, leadingEdgeDelayMs);
@@ -312,9 +274,7 @@ namespace QuixStreams.Streaming.Models.StreamProducer
             this.streamProducer.Publish(definitions);
         }
 
-        /// <summary>
-        /// Flushes internal buffers and disposes
-        /// </summary>
+        /// <inheritdoc/>
         public void Dispose()
         {
             if (this.isDisposed) return;

--- a/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducerExtensions.cs
+++ b/src/QuixStreams.Streaming/Models/StreamProducer/StreamTimeseriesProducerExtensions.cs
@@ -1,0 +1,34 @@
+﻿namespace QuixStreams.Streaming.Models.StreamProducer
+{
+    /// <summary>
+    /// Provides extension methods for <see cref="IStreamProducer"/>.
+    /// </summary>
+    public static class StreamTimeseriesProducerExtensions
+    {
+        /// <summary>
+        /// Creates a new <see cref="LeadingEdgeBuffer"/> using the <paramref name="producer"/> where tags form part of
+        /// the row's key and can't be modified after initial values
+        /// </summary>
+        /// <param name="producer">The timeseries stream producer</param>
+        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+        public static LeadingEdgeBuffer CreateLeadingEdgeBuffer(
+            this IStreamTimeseriesProducer producer,
+            int leadingEdgeDelayMs)
+        {
+            return new LeadingEdgeBuffer(producer, leadingEdgeDelayMs);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="LeadingEdgeTimeBuffer"/> using the <paramref name="producer"/> where tags do not
+        /// form part of the row's key and can be freely modified after initial values
+        /// </summary>
+        /// <param name="producer">The timeseries stream producer</param>
+        /// <param name="leadingEdgeDelayMs">Leading edge delay configuration in Milliseconds</param>
+        public static LeadingEdgeTimeBuffer CreateLeadingEdgeTimeBuffer(
+            this IStreamTimeseriesProducer producer,
+            int leadingEdgeDelayMs)
+        {
+            return new LeadingEdgeTimeBuffer(producer, leadingEdgeDelayMs);
+        }
+    }
+}

--- a/src/QuixStreams.Streaming/QuixStreamingClient.cs
+++ b/src/QuixStreams.Streaming/QuixStreamingClient.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -15,7 +15,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using QuixStreams;
 using QuixStreams.Kafka.Transport;
 using QuixStreams.Streaming.Configuration;
 using QuixStreams.Streaming.Exceptions;
@@ -29,7 +28,11 @@ using QuixStreams.Telemetry.Kafka;
 
 namespace QuixStreams.Streaming
 {
-    public interface IQuixStreamingClient
+    /// <summary>
+    /// Represents a streaming client for Kafka configured automatically using Environment Variables and Quix platform endpoints.
+    /// Use this Client when you use this library together with Quix platform.
+    /// </summary>
+    public interface IQuixStreamingClient : IQuixStreamingClientAsync
     {
         /// <summary>
         /// Gets a topic consumer capable of subscribing to receive incoming streams.
@@ -63,6 +66,46 @@ namespace QuixStreams.Streaming
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
         ITopicProducer GetTopicProducer(string topicIdOrName);
+    }
+
+    /// <summary>
+    /// Represents an asynchronous streaming client for Kafka configured automatically using Environment Variables and Quix platform endpoints.
+    /// Use this Client when you use this library together with Quix platform.
+    /// </summary>
+    public interface IQuixStreamingClientAsync
+    {
+        /// <summary>
+        /// Asynchronously gets a topic consumer capable of subscribing to receive incoming streams.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
+        /// <param name="options">The settings to use for committing</param>
+        /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <returns>A task returning an instance of <see cref="ITopicConsumer"/></returns>
+        Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest);
+
+        /// <summary>
+        /// Asynchronously gets a topic consumer capable of subscribing to receive non-quixstreams incoming messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
+        /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <returns>A task returning an instance of <see cref="IRawTopicConsumer"/></returns>
+        Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null);
+
+        /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <returns>A task returning an instance of <see cref="IRawTopicProducer"/></returns>
+        Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName);
+
+        /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <returns>A task returning an instance of <see cref="ITopicProducer"/></returns>
+        Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName);
     }
 
     /// <summary>
@@ -163,6 +206,17 @@ namespace QuixStreams.Streaming
             return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset);
         }
 
+        /// <inheritdoc/>
+        public async Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, ws) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+            (consumerGroup, options) = await GetValidConsumerGroup(topicIdOrName, consumerGroup, options).ConfigureAwait(false);
+
+            return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset);
+        }
+
         /// <summary>
         /// Gets a topic consumer capable of subscribing to receive non-quixstreams incoming messages. 
         /// </summary>
@@ -180,6 +234,17 @@ namespace QuixStreams.Streaming
             return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset);
         }
 
+        /// <inheritdoc/>
+        public async Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+            (consumerGroup, _) = await GetValidConsumerGroup(topicIdOrName, consumerGroup, null).ConfigureAwait(false);
+
+            return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset);
+        }
+
         /// <summary>
         /// Gets a topic producer capable of publishing non-quixstreams messages. 
         /// </summary>
@@ -193,7 +258,17 @@ namespace QuixStreams.Streaming
 
             return client.GetRawTopicProducer(topicId);
         }
-        
+
+        /// <inheritdoc/>
+        public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+
+            return client.GetRawTopicProducer(topicId);
+        }
+
         /// <summary>
         /// Gets a topic producer capable of publishing stream messages.
         /// </summary>
@@ -204,6 +279,16 @@ namespace QuixStreams.Streaming
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            return client.GetTopicProducer(topicId);
+        }
+
+        /// <inheritdoc/>
+        public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
 
             return client.GetTopicProducer(topicId);
         }

--- a/src/QuixStreams.Streaming/StreamConsumer.cs
+++ b/src/QuixStreams.Streaming/StreamConsumer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -54,13 +54,13 @@ namespace QuixStreams.Streaming
         public StreamConsumerId Id { get; }
         
         /// <inheritdoc />
-        public StreamPropertiesConsumer Properties => streamPropertiesConsumer;
+        public IStreamPropertiesConsumer Properties => streamPropertiesConsumer;
 
         /// <inheritdoc />
-        public StreamTimeseriesConsumer Timeseries => streamTimeseriesConsumer;
+        public IStreamTimeseriesConsumer Timeseries => streamTimeseriesConsumer;
 
         /// <inheritdoc />
-        public StreamEventsConsumer Events => streamEventsConsumer;
+        public IStreamEventsConsumer Events => streamEventsConsumer;
 
         /// <inheritdoc />
         public event EventHandler<PackageReceivedEventArgs> OnPackageReceived;
@@ -197,8 +197,8 @@ namespace QuixStreams.Streaming
             isClosed = true;
             this.logger.LogTrace("StreamConsumer: OnStreamEndReceived");
 
-            this.Timeseries.Buffers.ForEach(buffer => buffer.Dispose());
-            
+            this.streamTimeseriesConsumer.Buffers.ForEach(buffer => buffer.Dispose());
+
             this.OnStreamClosed?.Invoke(this, new StreamClosedEventArgs(this.topicConsumer, this, endType));
         }
 

--- a/src/QuixStreams.Streaming/StreamProducer.cs
+++ b/src/QuixStreams.Streaming/StreamProducer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -86,14 +86,13 @@ namespace QuixStreams.Streaming
         }
 
         /// <inheritdoc />
-        public StreamPropertiesProducer Properties => streamPropertiesProducer;
+        public IStreamPropertiesProducer Properties => streamPropertiesProducer;
 
         /// <inheritdoc />
-        public StreamTimeseriesProducer Timeseries => streamTimeseriesProducer;
+        public IStreamTimeseriesProducer Timeseries => streamTimeseriesProducer;
 
         /// <inheritdoc />
-        public StreamEventsProducer Events => streamEventsProducer;
-
+        public IStreamEventsProducer Events => streamEventsProducer;
 
         /// <inheritdoc />
         public void Publish(QuixStreams.Telemetry.Models.StreamProperties properties)


### PR DESCRIPTION
Proposes three updates to QuixStreams.Streaming library
* Use ConfigureAwait(false) for all awaited calls in QuixStreamingClient - this is to prevent deadlocks seen in WPF code
* Adds interfaces for common Quix types so that they can be mocked
* Adds async interface to QuixStreamingClient to avoid having to use GetAwaiter().GetResult(); to complete synchronously.