### PR TITLE
Improve memory footprint when reading split messages

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.6.2.0"
-informal_version = "0.6.2.0-dev1"
-nuget_version = "0.6.2.0-dev1"
+informal_version = "0.6.2.0-dev2"
+nuget_version = "0.6.2.0-dev2"
 
 
 def updatecsproj(projfilepath):

--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.6.2.0"
-informal_version = "0.6.2.0-dev2"
-nuget_version = "0.6.2.0-dev2"
+informal_version = "0.6.2.0-dev3"
+nuget_version = "0.6.2.0-dev3"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka.Transport/SerDes/Codecs/Codec.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/Codecs/Codec.cs
@@ -43,6 +43,7 @@ namespace QuixStreams.Kafka.Transport.SerDes.Codecs
             }
             catch (Exception ex)
             {
+                if (ex is OutOfMemoryException) throw;
                 logger.LogDebug(ex, "Failed to deserialize message with codec {0}", this.Id);
                 return false;
             }
@@ -59,6 +60,7 @@ namespace QuixStreams.Kafka.Transport.SerDes.Codecs
             }
             catch (Exception ex)
             {
+                if (ex is OutOfMemoryException) throw;
                 logger.LogDebug(ex, "Failed to deserialize message with codec {0}", this.Id);
                 return false;
             }

--- a/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageBuffer.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageBuffer.cs
@@ -45,7 +45,7 @@ namespace QuixStreams.Kafka.Transport.SerDes
         /// Initializes a new instance of <see cref="KafkaMessageBuffer"/>
         /// </summary>
         /// <param name="bufferPerMessageGroupKey">The number of different buffered message ids a group can have concurrently. Higher number might help with a producer that is interweaving multiple split message</param>
-        public KafkaMessageBuffer(int bufferPerMessageGroupKey = 500) : this(TimeSpan.FromSeconds(60), bufferPerMessageGroupKey)
+        public KafkaMessageBuffer(int bufferPerMessageGroupKey = 50) : this(TimeSpan.FromSeconds(60), bufferPerMessageGroupKey)
         {
         }
 

--- a/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMergerHelper.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMergerHelper.cs
@@ -34,6 +34,7 @@ namespace QuixStreams.Kafka.Transport.SerDes
         /// <inheritdoc />
         public MessageMergeResult TryMerge(KafkaMessage messageSegment, out MergerBufferId mergerBufferId, out KafkaMessage message)
         {
+            this.buffer.UpdateLatestMessageInfo(messageSegment);
             var key = messageSegment.Key == null ? string.Empty : Constants.Utf8NoBOMEncoding.GetString(messageSegment.Key);
             mergerBufferId = default(MergerBufferId);
             var messageIdBytes = messageSegment.Headers

--- a/src/QuixStreams.Kafka.Transport/TransportKafkaProducer.cs
+++ b/src/QuixStreams.Kafka.Transport/TransportKafkaProducer.cs
@@ -70,6 +70,8 @@ namespace QuixStreams.Kafka.Transport
                         // but this worked
                         var size = this.producer
                             .GetMaxMessageSizeBytes(TimeSpan.FromSeconds(5)).GetAwaiter().GetResult();
+
+                        if (size > 1000) size -= 1000; // This is done to offset kafka message overhead causing Message too Large exceptions
                         this.kafkaMessageSplitter = new KafkaMessageSplitter(size);
                     }
                 }


### PR DESCRIPTION
- Introduce maximum offset delta between message segments to prevent keeping messages that are unlikely to ever complete and discard before the timeout
- Fix split message buffering: the key was not correctly limiting the number of segments per kafka key. It was using the kafka key + id as unique id instead. Bug introduced in 0.6.0
- TTL split check was not iterating across all messages of a key, stopped after first to boot.