### PR TITLE
Use GZIP per message when required due to message size limit

### DIFF
--- a/src/QuixStreams.Kafka.Transport.Tests/KafkaTransportShould.cs
+++ b/src/QuixStreams.Kafka.Transport.Tests/KafkaTransportShould.cs
@@ -47,7 +47,7 @@ namespace QuixStreams.Kafka.Transport.Tests
         {
             yield return new object[] { PackageSerializationMode.LegacyValue, true, 500, 4};
             yield return new object[] { PackageSerializationMode.LegacyValue, false, 18, 1 };
-            yield return new object[] { PackageSerializationMode.Header, true, 500, 18 };
+            yield return new object[] { PackageSerializationMode.Header, true, 500, 14 };
             yield return new object[] { PackageSerializationMode.Header, false, 400, 1};
         }
     }

--- a/src/QuixStreams.Kafka.Transport.Tests/SerDes/KafkaMessageSplitterShould.cs
+++ b/src/QuixStreams.Kafka.Transport.Tests/SerDes/KafkaMessageSplitterShould.cs
@@ -208,7 +208,7 @@ namespace QuixStreams.Kafka.Transport.Tests.SerDes
             var segments = splitter.Split(message).ToList();
 
             // Assert
-            segments.Count.Should().Be(14);
+            segments.Count.Should().Be(9);
             foreach (var segment in segments)
             {
                 segment.MessageSize.Should().BeLessOrEqualTo(maxByteSize);
@@ -241,7 +241,7 @@ namespace QuixStreams.Kafka.Transport.Tests.SerDes
             var segments = splitter.Split(message).ToList();
 
             // Assert
-            segments.Count.Should().Be(14);
+            segments.Count.Should().Be(8);
             foreach (var segment in segments)
             {
                 segment.MessageSize.Should().BeLessOrEqualTo(maxByteSize);

--- a/src/QuixStreams.Kafka.Transport.Tests/SerDes/KafkaMessageSplitterShould.cs
+++ b/src/QuixStreams.Kafka.Transport.Tests/SerDes/KafkaMessageSplitterShould.cs
@@ -197,19 +197,28 @@ namespace QuixStreams.Kafka.Transport.Tests.SerDes
             var dataBytes = Encoding.UTF8.GetBytes(Newtonsoft.Json.JsonConvert.SerializeObject(data));
 
             var key = Encoding.UTF8.GetBytes("My super key");
-            var message = new KafkaMessage(key, dataBytes);
+            var testCodecId = "Stuff";
+            var headers = new KafkaHeader[]
+            {
+                new KafkaHeader(Constants.KafkaMessageHeaderCodecId, testCodecId)
+            };
+            var message = new KafkaMessage(key, dataBytes, headers);
 
             // Act
             var segments = splitter.Split(message).ToList();
 
             // Assert
-            segments.Count.Should().Be(9);
+            segments.Count.Should().Be(14);
             foreach (var segment in segments)
             {
                 segment.MessageSize.Should().BeLessOrEqualTo(maxByteSize);
                 var compression = Encoding.UTF8.GetString(segment.Headers
                     .First(y => y.Key == Constants.KafkaMessageHeaderCompression).Value);
                 compression.Should().Be("GZIP");
+                
+                var codecId = Encoding.UTF8.GetString(segment.Headers
+                    .First(y => y.Key == Constants.KafkaMessageHeaderCodecId).Value);
+                codecId.Should().Be($"[GZIP]-{testCodecId}");
             }
         }
     }

--- a/src/QuixStreams.Kafka.Transport/SerDes/Constants.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/Constants.cs
@@ -54,9 +54,9 @@ namespace QuixStreams.Kafka.Transport.SerDes
         internal const string KafkaMessageHeaderSplitMessageCount = "__Q_SplitMessageCount";
         
         /// <summary>
-        /// The compression used for the value itself to avoid message split or reduce segment count
+        /// The prefix used for GZIP compression in <see cref="KafkaMessageHeaderCodecId"/>
         /// </summary>
-        internal const string KafkaMessageHeaderCompression = "__Q_Compression";
+        internal const string KafkaMessageHeaderCodecIdGZipCompression = "[GZIP]";
 
 
     }

--- a/src/QuixStreams.Kafka.Transport/SerDes/Constants.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/Constants.cs
@@ -52,6 +52,11 @@ namespace QuixStreams.Kafka.Transport.SerDes
         /// The message segment count the message got split into
         /// </summary>
         internal const string KafkaMessageHeaderSplitMessageCount = "__Q_SplitMessageCount";
+        
+        /// <summary>
+        /// The compression used for the value itself to avoid message split or reduce segment count
+        /// </summary>
+        internal const string KafkaMessageHeaderCompression = "__Q_Compression";
 
 
     }

--- a/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMerger.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMerger.cs
@@ -138,12 +138,20 @@ namespace QuixStreams.Kafka.Transport.SerDes
                     var index = 0;
                     foreach (var messageHeader in message.Headers)
                     {
+                        var headerToUse = messageHeader;
                         // skip the compression header
                         if (messageHeader.Key == Constants.KafkaMessageHeaderCompression)
                         {
                             continue;
                         }
-                        headers[index] = messageHeader;
+
+                        if (messageHeader.Key == Constants.KafkaMessageHeaderCodecId)
+                        {
+                            var value = Encoding.UTF8.GetString(messageHeader.Value);
+                            var newValue = value.Replace("[GZIP]-", "");
+                            headerToUse = new KafkaHeader(messageHeader.Key, newValue);
+                        }
+                        headers[index] = headerToUse;
                         index++;
                     }
                 }

--- a/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageSplitter.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageSplitter.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Logging;
 using QuixStreams.Kafka.Transport.SerDes.Legacy;
 
@@ -55,6 +58,11 @@ namespace QuixStreams.Kafka.Transport.SerDes
         internal static int ExpectedHeaderSplitInfoSize = KafkaMessage.EstimateHeaderSize(
             CreateSegmentDictionary(int.MaxValue, BitConverter.GetBytes(int.MaxValue), Guid.NewGuid().ToByteArray()));
 
+        internal static int ExpectedCompressionInfoSize = KafkaMessage.EstimateHeaderSize(new Dictionary<string, byte[]>()
+        {
+            { Constants.KafkaMessageHeaderCompression, new KafkaHeader("", "GZIP").Value}
+        });
+        
         /// <summary>
         /// Initializes a new instance of <see cref="KafkaMessageSplitter"/>
         /// </summary>
@@ -115,28 +123,89 @@ namespace QuixStreams.Kafka.Transport.SerDes
                 logger.LogWarning("A message could not be split because your message limit is {0} bytes.", this.MaximumKafkaMessageSize);
                 yield return message;
             }
+            
+            var compressedMessage = CompressMessage(message);
+            KafkaMessage messageToSplit = compressedMessage;
+            if (compressedMessage.MessageSize > message.MessageSize)
+            {
+                // Use original, less overhead
+                messageToSplit = message;
+                compressedMessage = null;
+            }
+            else
+            {
+                var compressedValueSizeMax = valueSizeMax - ExpectedCompressionInfoSize;
+                var compressedCount = (int)Math.Ceiling((double)compressedMessage.Value.Length / compressedValueSizeMax);
+                var nonCompressedCount = (int)Math.Ceiling((double)message.Value.Length / valueSizeMax);
+
+                if (nonCompressedCount <= compressedCount)
+                {
+                    // Use original, less overhead
+                    messageToSplit = message;
+                    compressedMessage = null;
+                }
+                else
+                {
+                    valueSizeMax = compressedValueSizeMax;
+                    if (compressedCount == 1) 
+                    {
+                        // Due to compression there is is nothing to split
+                        yield return messageToSplit;
+                        yield break;
+                    }
+                }
+            }
 
             var messageId = Guid.NewGuid().ToByteArray();
-            var count = (int)Math.Ceiling((double)message.Value.Length / valueSizeMax);
+            var count = (int)Math.Ceiling((double)messageToSplit.Value.Length / valueSizeMax);
             var countAsBytes = BitConverter.GetBytes(count);
             var start = 0;
             for (int index = 0; index < count; index++)
             {
-                var end = Math.Min(start + valueSizeMax, message.Value.Length); // non inclusive
+                var end = Math.Min(start + valueSizeMax, messageToSplit.Value.Length); // non inclusive
                 var length = end - start;
                 var segment = new byte[length];
-                Array.Copy(message.Value, start, segment, 0, length);
+                Array.Copy(messageToSplit.Value, start, segment, 0, length);
                 var headers = CreateSegmentDictionary(index, countAsBytes, messageId);
-                var messageHeaders = message.Headers?.ToList() ?? new List<KafkaHeader>();
+                var messageHeaders = messageToSplit.Headers?.ToList() ?? new List<KafkaHeader>();
                 foreach (var header in headers)
                 {
                     messageHeaders.Add(new KafkaHeader(header.Key, header.Value));
                 }
 
-                var segmentMessage = new KafkaMessage(message.Key, segment, messageHeaders.ToArray());
+                var segmentMessage = new KafkaMessage(messageToSplit.Key, segment, messageHeaders.ToArray());
                 yield return segmentMessage;
                 start = end;
             }
+        }
+
+        private KafkaMessage CompressMessage(KafkaMessage message)
+        {
+            using (var compressedStream = new MemoryStream())
+            using (var zipStream = new GZipStream(compressedStream, CompressionLevel.Optimal))
+            {
+                zipStream.Write(message.Value, 0, message.Value.Length);
+                zipStream.Close();
+                var headers = ExtendHeaderByN(message.Headers, 1);
+                headers[headers.Length-1] = new KafkaHeader(Constants.KafkaMessageHeaderCompression, "GZIP");
+
+                var compressed = compressedStream.ToArray();
+                
+                return new KafkaMessage(message.Key, compressed, headers, message.Timestamp);
+            }
+        }
+
+        private KafkaHeader[] ExtendHeaderByN(KafkaHeader[] headers, int number)
+        {
+            if (headers == null) return new KafkaHeader[number];
+            var extendedHeaders = new KafkaHeader[headers.Length + number];
+            for (var index = 0; index < headers.Length; index++)
+            {
+                var kafkaHeader = headers[index];
+                extendedHeaders[index] = kafkaHeader;
+            }
+
+            return extendedHeaders;
         }
 
         internal static IDictionary<string, byte[]> CreateSegmentDictionary(int index, byte[] countBytes, byte[] messageGuidBytes)

--- a/src/QuixStreams.Streaming.IntegrationTests/KafkaStreamingClientIntegrationTests.cs
+++ b/src/QuixStreams.Streaming.IntegrationTests/KafkaStreamingClientIntegrationTests.cs
@@ -162,7 +162,7 @@ namespace QuixStreams.Streaming.IntegrationTests
             var expectedData = ProduceRandomData("stream-1");
             ProduceRandomData("ADifferentstream");
             
-            var topicConsumer = client.GetTopicConsumer(topic, new PartitionOffset(1, 2));
+            var topicConsumer = client.GetTopicConsumer(topic, new PartitionOffset(1, 1));
 
             var totalPackages = 0;
             var streamEndReceived = false;

--- a/src/QuixStreams.Tester/Configuration.cs
+++ b/src/QuixStreams.Tester/Configuration.cs
@@ -59,8 +59,14 @@ namespace QuixStreams.Tester
         public int NumberOfStreams { get; set; }
         
         public bool TimeseriesEnabled => TimeseriesRate > 0;
+        public int TimeseriesParameterCount { get; set; }
+
+        public int ParameterDefinitionCount { get; set; }
 
         public bool EventsEnabled => EventRate > 0;
+        
+        public int EventDefinitionCount { get; set; }
+
         
 
         public double EventRate { get; set; }

--- a/src/QuixStreams.Tester/appsettings.json
+++ b/src/QuixStreams.Tester/appsettings.json
@@ -1,18 +1,18 @@
 {
     "KafkaConfiguration": {
-        "Topic" : "test_topic4",
+        "Topic" : "test_topic3",
         "BrokerList" : "127.0.0.1:9092",
-        "ConsumerGroup" : "test_topic"
+        "ConsumerGroup" : "test_topic2"
     },
     "Mode" : "Consumer", // Producer or Consumer
     "ProducerConfig": {
         "NumberOfStreams": 1,
         "EventRate": 0, // per second, 0 to disable
         "TimeseriesRate": 1000, // per second, 0 to disable
-        "TimeseriesParameterCount": 300,
-        "RowPerTimeseries": 10, // will overlap above 1K
-        "ParameterDefinitionCount": 0,
-        "EventDefinitionCount": 0
+        "TimeseriesParameterCount": 3000,
+        "RowPerTimeseries": 100, // will overlap above 1K
+        "ParameterDefinitionCount": 30000,
+        "EventDefinitionCount": 2000
     },
     "ConsumerConfig": {
         "PrintStreams": false,

--- a/src/QuixStreams.Tester/appsettings.json
+++ b/src/QuixStreams.Tester/appsettings.json
@@ -8,8 +8,11 @@
     "ProducerConfig": {
         "NumberOfStreams": 1,
         "EventRate": 0, // per second, 0 to disable
-        "TimeseriesRate": 100000, // per second, 0 to disable
-        "RowPerTimeseries": 2 // will overlap above 1K
+        "TimeseriesRate": 1000, // per second, 0 to disable
+        "TimeseriesParameterCount": 300,
+        "RowPerTimeseries": 10, // will overlap above 1K
+        "ParameterDefinitionCount": 0,
+        "EventDefinitionCount": 0
     },
     "ConsumerConfig": {
         "PrintStreams": false,


### PR DESCRIPTION
Improve on existing large message handling by doing individual message compression to fall below allowed message size limit. The change is only applied to Header based protocol, which is not yet enabled as default, so the change should be non intrusive.
Also fixed broken unit test caused in previous merges.