### PR TITLE
Adds ability to produce to a specific partition

### DIFF
--- a/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -55,6 +55,11 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             return topicProducer;
         }
 
+        public ITopicProducer GetTopicProducer(string topic, int partitionId)
+        {
+            return GetTopicProducer(topic);
+        }
+
         private TestBroker GetBroker(string topic)
         {
             if (this.brokers.TryGetValue(topic, out var broker)) return broker;
@@ -119,6 +124,11 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             throw new NotImplementedException();
         }
 
+        IRawTopicProducer IQuixStreamingClient.GetRawTopicProducer(string topicIdOrName, int partitionId)
+        {
+            throw new NotImplementedException();
+        }
+
         ITopicProducer IQuixStreamingClient.GetTopicProducer(string topicIdOrName)
         {
             return GetTopicProducer(topicIdOrName);
@@ -153,9 +163,19 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicProducer(topicIdOrName));
         }
 
+        Task<IRawTopicProducer> IQuixStreamingClientAsync.GetRawTopicProducerAsync(string topicIdOrName, int partitionId)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicProducer(topicIdOrName, partitionId));
+        }
+
         Task<ITopicProducer> IQuixStreamingClientAsync.GetTopicProducerAsync(string topicIdOrName)
         {
             return Task.FromResult(((IQuixStreamingClient)this).GetTopicProducer(topicIdOrName));
+        }
+
+        Task<ITopicProducer> IQuixStreamingClientAsync.GetTopicProducerAsync(string topicIdOrName, int partitionId)
+        {
+            return Task.FromResult(((IQuixStreamingClient)this).GetTopicProducer(topicIdOrName, partitionId));
         }
     }
 }

--- a/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Confluent.Kafka;
 using QuixStreams.Kafka;
 using QuixStreams.Kafka.Transport;
 using QuixStreams.Kafka.Transport.Tests.Helpers;
@@ -19,7 +18,6 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
         private TelemetryKafkaConsumer telemetryKafkaConsumer;
         private Func<string, TelemetryKafkaProducer> createKafkaProducer;
         private Dictionary<string, TestBroker> brokers = new Dictionary<string, TestBroker>();
-
 
         public TestStreamingClient(CodecType codec = CodecType.Protobuf, TimeSpan publishDelay = default)
         {
@@ -85,7 +83,17 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             throw new NotImplementedException();
         }
 
+        IRawTopicProducer IKafkaStreamingClient.GetRawTopicProducer(string topic, int partitionId)
+        {
+            throw new NotImplementedException();
+        }
+
         ITopicProducer IKafkaStreamingClient.GetTopicProducer(string topic)
+        {
+            return GetTopicProducer(topic);
+        }
+
+        ITopicProducer IKafkaStreamingClient.GetTopicProducer(string topic, int partitionId)
         {
             return GetTopicProducer(topic);
         }

--- a/src/QuixStreams.Streaming/KafkaStreamingClient.cs
+++ b/src/QuixStreams.Streaming/KafkaStreamingClient.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
-using QuixStreams;
 using QuixStreams.Kafka;
 using QuixStreams.Kafka.Transport;
 using QuixStreams.Streaming.Configuration;
@@ -54,11 +52,27 @@ namespace QuixStreams.Streaming
         IRawTopicProducer GetRawTopicProducer(string topic);
 
         /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        IRawTopicProducer GetRawTopicProducer(string topic, int partitionId);
+
+        /// <summary>
         /// Gets a topic producer capable of publishing stream messages. 
         /// </summary>
         /// <param name="topic">Name of the topic.</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
         ITopicProducer GetTopicProducer(string topic);
+
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        ITopicProducer GetTopicProducer(string topic, int partitionId);
     }
 
     /// <summary>
@@ -207,6 +221,22 @@ namespace QuixStreams.Streaming
             var rawTopicProducer = new RawTopicProducer(brokerAddress, topic, brokerProperties);
 
             App.Register(rawTopicProducer);
+
+            return rawTopicProducer;
+        }
+
+        /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        public IRawTopicProducer GetRawTopicProducer(string topic, int partitionId)
+        {
+            var rawTopicProducer = new RawTopicProducer(brokerAddress, topic, brokerProperties, partitionId);
+
+            App.Register(rawTopicProducer);
+
             return rawTopicProducer;
         }
         
@@ -219,6 +249,21 @@ namespace QuixStreams.Streaming
         {
             var topicProducer = new TopicProducer(new KafkaProducerConfiguration(brokerAddress, brokerProperties), topic);
             
+            App.Register(topicProducer);
+
+            return topicProducer;
+        }
+
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        public ITopicProducer GetTopicProducer(string topic, int partitionId)
+        {
+            var topicProducer = new TopicProducer(new KafkaProducerConfiguration(brokerAddress, brokerProperties), topic, partitionId);
+
             App.Register(topicProducer);
 
             return topicProducer;

--- a/src/QuixStreams.Streaming/QuixStreamingClient.cs
+++ b/src/QuixStreams.Streaming/QuixStreamingClient.cs
@@ -13,7 +13,6 @@ using System.Security.Authentication;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using QuixStreams.Kafka;
@@ -74,11 +73,27 @@ namespace QuixStreams.Streaming
         IRawTopicProducer GetRawTopicProducer(string topicIdOrName);
 
         /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        IRawTopicProducer GetRawTopicProducer(string topic, int partitionId);
+
+        /// <summary>
         /// Gets a topic producer capable of publishing stream messages.
         /// </summary>
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
         ITopicProducer GetTopicProducer(string topicIdOrName);
+
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        ITopicProducer GetTopicProducer(string topic, int partitionId);
     }
 
     /// <summary>
@@ -124,11 +139,27 @@ namespace QuixStreams.Streaming
         Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName);
 
         /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>A task returning an instance of <see cref="IRawTopicProducer"/></returns>
+        Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, int partitionId);
+
+        /// <summary>
         /// Asynchronously gets a topic producer capable of publishing stream messages.
         /// </summary>
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
         /// <returns>A task returning an instance of <see cref="ITopicProducer"/></returns>
         Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName);
+
+        /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>A task returning an instance of <see cref="ITopicProducer"/></returns>
+        Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, int partitionId);
     }
 
     /// <summary>
@@ -337,6 +368,21 @@ namespace QuixStreams.Streaming
             return client.GetRawTopicProducer(topicId);
         }
 
+        /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        public IRawTopicProducer GetRawTopicProducer(string topicIdOrName, int partitionId)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            return client.GetRawTopicProducer(topicId, partitionId);
+        }
+
         /// <inheritdoc/>
         public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName)
         {
@@ -346,6 +392,17 @@ namespace QuixStreams.Streaming
 
             return client.GetRawTopicProducer(topicId);
         }
+
+        /// <inheritdoc/>
+        public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, int partitionId)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+
+            return client.GetRawTopicProducer(topicId, partitionId);
+        }
+
 
         /// <summary>
         /// Gets a topic producer capable of publishing stream messages.
@@ -361,6 +418,21 @@ namespace QuixStreams.Streaming
             return client.GetTopicProducer(topicId);
         }
 
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        public ITopicProducer GetTopicProducer(string topicIdOrName, int partitionId)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            return client.GetTopicProducer(topicId, partitionId);
+        }
+
         /// <inheritdoc/>
         public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName)
         {
@@ -369,6 +441,16 @@ namespace QuixStreams.Streaming
             var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
 
             return client.GetTopicProducer(topicId);
+        }
+
+        /// <inheritdoc/>
+        public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, int partitionId)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+
+            return client.GetTopicProducer(topicId, partitionId);
         }
 
         private async Task<(string, CommitOptions)> GetValidConsumerGroup(string topicIdOrName, string originalConsumerGroup, CommitOptions commitOptions)

--- a/src/QuixStreams.Streaming/Raw/RawTopicProducer.cs
+++ b/src/QuixStreams.Streaming/Raw/RawTopicProducer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using QuixStreams.Kafka;
 
@@ -25,6 +26,18 @@ namespace QuixStreams.Streaming.Raw
         /// <param name="topicName">Name of the topic.</param>
         /// <param name="brokerProperties">Additional broker properties</param>
         public RawTopicProducer(string brokerAddress, string topicName, Dictionary<string, string> brokerProperties = null)
+            : this(brokerAddress, topicName, brokerProperties, Partition.Any)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="RawTopicProducer"/>
+        /// </summary>
+        /// <param name="brokerAddress">Address of Kafka cluster.</param>
+        /// <param name="topicName">Name of the topic.</param>
+        /// <param name="partition">Partition to produce to.</param>
+        /// <param name="brokerProperties">Additional broker properties</param>
+        public RawTopicProducer(string brokerAddress, string topicName, Dictionary<string, string> brokerProperties, Partition partition)
         {
             brokerProperties ??= new Dictionary<string, string>();
             if (!brokerProperties.ContainsKey("queued.max.messages.kbytes")) brokerProperties["queued.max.messages.kbytes"] = "20480";
@@ -32,11 +45,11 @@ namespace QuixStreams.Streaming.Raw
             this.topicName = topicName;
 
             var publisherConfiguration = new QuixStreams.Kafka.ProducerConfiguration(brokerAddress, brokerProperties);
-            var topicConfiguration = new QuixStreams.Kafka.ProducerTopicConfiguration(this.topicName);
+            var topicConfiguration = new QuixStreams.Kafka.ProducerTopicConfiguration(this.topicName, partition);
 
             this.kafkaProducer = new KafkaProducer(publisherConfiguration, topicConfiguration);
         }
-        
+
         /// <summary>
         /// Initializes a new instance of <see cref="RawTopicProducer"/>
         /// </summary>

--- a/src/QuixStreams.Streaming/TopicProducer.cs
+++ b/src/QuixStreams.Streaming/TopicProducer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using QuixStreams.Kafka;
 using QuixStreams.Telemetry.Kafka;
@@ -32,15 +33,28 @@ namespace QuixStreams.Streaming
         }
         
         /// <summary>
-        /// Initializes a new instance of <see cref="TopicProducer"/>
+        /// Initializes a new instance of the <see cref="TopicProducer"/> class.
         /// </summary>
+        /// <param name="config">Kafka producer configuration.</param>
+        /// <param name="topic">Name of the topic.</param>
         public TopicProducer(KafkaProducerConfiguration config, string topic)
+            : this(config, topic, Partition.Any)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TopicProducer"/> class.
+        /// </summary>
+        /// <param name="config">Kafka producer configuration.</param>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partition">Partition to produce to.</param>
+        public TopicProducer(KafkaProducerConfiguration config, string topic, Partition partition)
         {
             this.topic = topic;
-            
+
             var prodConfig = new ProducerConfiguration(config.BrokerList, config.Properties);
-            var topicConfig = new ProducerTopicConfiguration(topic);
-            
+            var topicConfig = new ProducerTopicConfiguration(topic, partition);
+
             this.kafkaProducer =  new KafkaProducer(prodConfig, topicConfig);
 
             createKafkaProducer = (string streamId) => new TelemetryKafkaProducer(this.kafkaProducer, streamId);


### PR DESCRIPTION
This change adds support for specifying the id of the partition to produce to. 
I wasn't sure whether to expose the public method with the Confluent Partition type or as an integer, so for now I have used integer arguments on the main external apis.