### PR TITLE
Improve partition support when producing/consuming message

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.6.4.0"
-informal_version = "0.6.4.0-dev7"
-nuget_version = "0.6.4.0-dev7"
+informal_version = "0.6.4.0-dev8"
+nuget_version = "0.6.4.0-dev8"
 
 
 def updatecsproj(projfilepath):

--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.6.4.0"
-informal_version = "0.6.4.0-dev5"
-nuget_version = "0.6.4.0-dev5"
+informal_version = "0.6.4.0-dev6"
+nuget_version = "0.6.4.0-dev6"
 
 
 def updatecsproj(projfilepath):

--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.6.4.0"
-informal_version = "0.6.4.0-dev6"
-nuget_version = "0.6.4.0-dev6"
+informal_version = "0.6.4.0-dev7"
+nuget_version = "0.6.4.0-dev7"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka/KafkaHelper.cs
+++ b/src/QuixStreams.Kafka/KafkaHelper.cs
@@ -65,7 +65,8 @@ namespace QuixStreams.Kafka
                 // Example:  [WAKEUP] [thrd:main]: 127.0.0.1:53631/0: Wake-up: ready to fetch
                 if (logMessage.Level != SyslogLevel.Debug) return false;
                 if (!string.Equals("WAKEUP", logMessage.Facility, StringComparison.InvariantCultureIgnoreCase)) return false;
-                if (!logMessage.Message.Contains("Wake-up: ready to fetch")) return false;
+                if (!logMessage.Message.Contains("Wake-up: ready to fetch")
+                    && !logMessage.Message.Contains("Wake-up: fetch start")) return false;
                 readyToFetch = true;
                 return true;
             }

--- a/src/QuixStreams.Kafka/KafkaMessage.cs
+++ b/src/QuixStreams.Kafka/KafkaMessage.cs
@@ -41,7 +41,7 @@ namespace QuixStreams.Kafka
         public int HeaderSize { get; protected set; }
         
         /// <summary>
-        /// The topic partition offset associated with the message. Can be null.
+        /// The topic partition offset associated with the message. Null when the message is not read from broker.
         /// </summary>
         public TopicPartitionOffset TopicPartitionOffset { get; protected set; }
         

--- a/src/QuixStreams.Kafka/TopicConfiguration.cs
+++ b/src/QuixStreams.Kafka/TopicConfiguration.cs
@@ -190,7 +190,7 @@ namespace QuixStreams.Kafka
         /// <param name="topic">The topic to set the partitions for</param>
         /// <param name="partitions">The partitions to set the offset for</param>
         /// <param name="offset">The offset</param>
-        public ConsumerTopicConfiguration(string topic, ICollection<Partition> partitions, Offset offset) : this(topic, partitions.Select(p => new PartitionOffset(p.Value, offset)).ToList())
+        public ConsumerTopicConfiguration(string topic, ICollection<Partition> partitions, Offset offset) : this(topic, partitions?.Select(p => new PartitionOffset(p.Value, offset)).ToList() ?? new List<PartitionOffset> { new PartitionOffset(Partition.Any, Offset.Unset)})
         {
         }
 

--- a/src/QuixStreams.Streaming.IntegrationTests/StreamingRawIntegrationTests.cs
+++ b/src/QuixStreams.Streaming.IntegrationTests/StreamingRawIntegrationTests.cs
@@ -1,13 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Confluent.Kafka;
+using FluentAssertions;
 using Quix.TestBase.Extensions;
 using QuixStreams.Kafka;
 using QuixStreams;
-using QuixStreams.Telemetry.Kafka;
 using Xunit;
 using Xunit.Abstractions;
+using AutoOffsetReset = QuixStreams.Telemetry.Kafka.AutoOffsetReset;
 
 namespace QuixStreams.Streaming.IntegrationTests
 {
@@ -64,8 +67,6 @@ namespace QuixStreams.Streaming.IntegrationTests
             var topicName = "streaming-raw-integration-test2";
             await this.kafkaDockerTestFixture.EnsureTopic(topicName, 1);
             
-            var justCreateMeMyTopic = client.GetRawTopicProducer(topicName);
-            justCreateMeMyTopic.Dispose(); // should cause a flush
             Thread.Sleep(5000); // This is only necessary because the container we use for kafka and how a topic creation is handled for the unit test
 
             var topicConsumer = client.GetRawTopicConsumer(topicName, "Default", AutoOffsetReset.Earliest);
@@ -87,6 +88,89 @@ namespace QuixStreams.Streaming.IntegrationTests
 
             Assert.Single(received);
             Assert.Equal(toSend, received[0]);
+
+
+            topicConsumer.Dispose();
+            topicProducer.Dispose();
+        }
+        
+        [Fact]
+        public async Task StreamToPartition_ShouldReadExpected()
+        {
+            var topicName = "StreamToPartition_ShouldReadExpected";
+            await this.kafkaDockerTestFixture.EnsureTopic(topicName, 16);
+            
+            Thread.Sleep(5000); // This is only necessary because the container we use for kafka and how a topic creation is handled for the unit test
+
+            var topicConsumer = client.GetRawTopicConsumer(topicName, "Default", AutoOffsetReset.Earliest);
+
+            var toSend = new byte[] { 1, 2, 0, 4, 6, 123, 54, 2 };
+            var received = new List<KafkaMessage>();
+
+
+            topicConsumer.OnMessageReceived += (sender, message) =>
+            {
+                received.Add(message);
+            };
+
+            topicConsumer.Subscribe();
+            var topicProducer = client.GetRawTopicProducer(topicName, new Partition(11));
+            topicProducer.Publish(new KafkaMessage(null, toSend, null));
+            var random = new Random();
+            for (var ii = 0; ii < 100; ii++)
+            {
+                var key = new byte[64];
+                random.NextBytes(key);
+                topicProducer.Publish(new KafkaMessage(key, toSend, null));
+            }
+
+
+            SpinWait.SpinUntil(() => received.Count == 101, 5000);
+
+            received.Count.Should().Be(101);
+            received.All(y => y.TopicPartitionOffset.Partition.Value == 11).Should().BeTrue();
+
+
+            topicConsumer.Dispose();
+            topicProducer.Dispose();
+        }
+        
+        [Fact]
+        public async Task StreamWithPartitioner_ShouldReadExpected()
+        {
+            var topicName = "StreamWithPartitioner_ShouldReadExpected";
+            await this.kafkaDockerTestFixture.EnsureTopic(topicName, 16);
+            
+            Thread.Sleep(5000); // This is only necessary because the container we use for kafka and how a topic creation is handled for the unit test
+
+            var topicConsumer = client.GetRawTopicConsumer(topicName, "Default", AutoOffsetReset.Earliest);
+
+            var toSend = new byte[] { 1, 2, 0, 4, 6, 123, 54, 2 };
+            var received = new List<KafkaMessage>();
+
+
+            topicConsumer.OnMessageReceived += (sender, message) =>
+            {
+                received.Add(message);
+            };
+
+            topicConsumer.Subscribe();
+            QuixPartitionerDelegate partitioner = (topic, count, message) => 14;
+            var topicProducer = client.GetRawTopicProducer(topicName,  partitioner);
+            topicProducer.Publish(new KafkaMessage(null, toSend, null));
+            var random = new Random();
+            for (var ii = 0; ii < 100; ii++)
+            {
+                var key = new byte[64];
+                random.NextBytes(key);
+                topicProducer.Publish(new KafkaMessage(key, toSend, null));
+            }
+
+
+            SpinWait.SpinUntil(() => received.Count == 101, 5000);
+
+            received.Count.Should().Be(101);
+            received.All(y => y.TopicPartitionOffset.Partition.Value == 14).Should().BeTrue();
 
 
             topicConsumer.Dispose();

--- a/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -74,7 +74,7 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             return broker;
         }
         
-        public IRawTopicConsumer GetRawTopicConsumer(string topic, string consumerGroup, AutoOffsetReset? autoOffset)
+        public IRawTopicConsumer GetRawTopicConsumer(string topic, string consumerGroup, AutoOffsetReset? autoOffset, ICollection<Partition> partitions = null)
         {
             throw new NotImplementedException();
         }
@@ -99,7 +99,7 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             return GetTopicProducer(topic);
         }
 
-        public ITopicConsumer GetTopicConsumer(string topic, string consumerGroup, CommitOptions options, AutoOffsetReset autoOffset)
+        public ITopicConsumer GetTopicConsumer(string topic, string consumerGroup, CommitOptions options, AutoOffsetReset autoOffset, ICollection<Partition> partitions)
         {
             return GetTopicConsumer(topic);
         }
@@ -113,9 +113,10 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             string topicIdOrName,
             string consumerGroup,
             CommitOptions options,
-            AutoOffsetReset autoOffset)
+            AutoOffsetReset autoOffset,
+            ICollection<Partition> partitions)
         {
-            return Task.FromResult(GetTopicConsumer(topicIdOrName, consumerGroup, options, autoOffset));
+            return Task.FromResult(GetTopicConsumer(topicIdOrName, consumerGroup, options, autoOffset, partitions));
         }
         
         
@@ -128,7 +129,7 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             return Task.FromResult(GetTopicConsumer(topicIdOrName, offset, consumerGroup, options));
         }
 
-        public Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup, AutoOffsetReset? autoOffset)
+        public Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup, AutoOffsetReset? autoOffset, ICollection<Partition> partitions)
         {
             return Task.FromResult(GetRawTopicConsumer(topicIdOrName, consumerGroup, autoOffset));
         }

--- a/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
+++ b/src/QuixStreams.Streaming.UnitTests/Helpers/TestStreamingClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Confluent.Kafka;
 using QuixStreams.Kafka;
 using QuixStreams.Kafka.Transport;
 using QuixStreams.Kafka.Transport.Tests.Helpers;
@@ -43,6 +44,11 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
         public ITopicProducer GetTopicProducer()
         {
             return GetTopicProducer("DEFAULT");
+        }   
+
+        public IRawTopicProducer GetRawTopicProducer(string topic, QuixPartitionerDelegate partitioner)
+        {
+            return GetRawTopicProducer(topic);
         }
 
         public ITopicProducer GetTopicProducer(string topic)
@@ -67,115 +73,94 @@ namespace QuixStreams.Streaming.UnitTests.Helpers
             this.brokers[topic] = broker;
             return broker;
         }
-
-        ITopicConsumer IQuixStreamingClient.GetTopicConsumer(string topicIdOrName, string consumerGroup, CommitOptions options, AutoOffsetReset autoOffset)
-        {
-            return GetTopicConsumer(topicIdOrName);
-        }
-
-        ITopicConsumer IQuixStreamingClient.GetTopicConsumer(string topicIdOrName, PartitionOffset offset, string consumerGroup, CommitOptions options = null)
-        {
-            return GetTopicConsumer(topicIdOrName);
-        }
         
-        IRawTopicConsumer IKafkaStreamingClient.GetRawTopicConsumer(string topic, string consumerGroup, AutoOffsetReset? autoOffset)
+        public IRawTopicConsumer GetRawTopicConsumer(string topic, string consumerGroup, AutoOffsetReset? autoOffset)
         {
             throw new NotImplementedException();
         }
 
-        IRawTopicProducer IKafkaStreamingClient.GetRawTopicProducer(string topic)
+        public IRawTopicProducer GetRawTopicProducer(string topic)
         {
             throw new NotImplementedException();
         }
 
-        IRawTopicProducer IKafkaStreamingClient.GetRawTopicProducer(string topic, int partitionId)
+        public IRawTopicProducer GetRawTopicProducer(string topic, Partition partition)
         {
-            throw new NotImplementedException();
+            return GetRawTopicProducer(topic);
         }
 
-        ITopicProducer IKafkaStreamingClient.GetTopicProducer(string topic)
+        public ITopicProducer GetTopicProducer(string topic, Partition partition)
         {
             return GetTopicProducer(topic);
         }
 
-        ITopicProducer IKafkaStreamingClient.GetTopicProducer(string topic, int partitionId)
+        public ITopicProducer GetTopicProducer(string topic, StreamPartitionerDelegate partitioner)
         {
             return GetTopicProducer(topic);
         }
 
-        ITopicConsumer IKafkaStreamingClient.GetTopicConsumer(string topic, string consumerGroup, CommitOptions options, AutoOffsetReset autoOffset)
+        public ITopicConsumer GetTopicConsumer(string topic, string consumerGroup, CommitOptions options, AutoOffsetReset autoOffset)
         {
             return GetTopicConsumer(topic);
         }
         
-        ITopicConsumer IKafkaStreamingClient.GetTopicConsumer(string topic, PartitionOffset partitionOffset, string consumerGroup, CommitOptions options)
+        public ITopicConsumer GetTopicConsumer(string topic, PartitionOffset partitionOffset, string consumerGroup, CommitOptions options)
         {
             return GetTopicConsumer(topic);
         }
 
-        IRawTopicConsumer IQuixStreamingClient.GetRawTopicConsumer(string topicIdOrName, string consumerGroup,
-            AutoOffsetReset? autoOffset)
-        {
-            throw new NotImplementedException();
-        }
-
-        IRawTopicProducer IQuixStreamingClient.GetRawTopicProducer(string topicIdOrName)
-        {
-            throw new NotImplementedException();
-        }
-
-        IRawTopicProducer IQuixStreamingClient.GetRawTopicProducer(string topicIdOrName, int partitionId)
-        {
-            throw new NotImplementedException();
-        }
-
-        ITopicProducer IQuixStreamingClient.GetTopicProducer(string topicIdOrName)
-        {
-            return GetTopicProducer(topicIdOrName);
-        }
-
-        Task<ITopicConsumer> IQuixStreamingClientAsync.GetTopicConsumerAsync(
+        public Task<ITopicConsumer> GetTopicConsumerAsync(
             string topicIdOrName,
             string consumerGroup,
             CommitOptions options,
             AutoOffsetReset autoOffset)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetTopicConsumer(topicIdOrName, consumerGroup, options, autoOffset));
+            return Task.FromResult(GetTopicConsumer(topicIdOrName, consumerGroup, options, autoOffset));
         }
         
         
-        Task<ITopicConsumer> IQuixStreamingClientAsync.GetTopicConsumerAsync(
+        public Task<ITopicConsumer> GetTopicConsumerAsync(
             string topicIdOrName,
             PartitionOffset offset,
             string consumerGroup,
             CommitOptions options)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetTopicConsumer(topicIdOrName, consumerGroup, options));
+            return Task.FromResult(GetTopicConsumer(topicIdOrName, offset, consumerGroup, options));
         }
 
-        Task<IRawTopicConsumer> IQuixStreamingClientAsync.GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup, AutoOffsetReset? autoOffset)
+        public Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup, AutoOffsetReset? autoOffset)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicConsumer(topicIdOrName, consumerGroup, autoOffset));
+            return Task.FromResult(GetRawTopicConsumer(topicIdOrName, consumerGroup, autoOffset));
         }
 
-        Task<IRawTopicProducer> IQuixStreamingClientAsync.GetRawTopicProducerAsync(string topicIdOrName)
+        public Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicProducer(topicIdOrName));
+            return Task.FromResult(GetRawTopicProducer(topicIdOrName));
         }
 
-        Task<IRawTopicProducer> IQuixStreamingClientAsync.GetRawTopicProducerAsync(string topicIdOrName, int partitionId)
+        public Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, Partition partition)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetRawTopicProducer(topicIdOrName, partitionId));
+            return Task.FromResult(GetRawTopicProducer(topicIdOrName, partition));
         }
 
-        Task<ITopicProducer> IQuixStreamingClientAsync.GetTopicProducerAsync(string topicIdOrName)
+        public Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, QuixPartitionerDelegate partitioner)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetTopicProducer(topicIdOrName));
+            return Task.FromResult(GetRawTopicProducer(topicIdOrName, partitioner));
         }
 
-        Task<ITopicProducer> IQuixStreamingClientAsync.GetTopicProducerAsync(string topicIdOrName, int partitionId)
+        public Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName)
         {
-            return Task.FromResult(((IQuixStreamingClient)this).GetTopicProducer(topicIdOrName, partitionId));
+            return Task.FromResult(GetTopicProducer(topicIdOrName));
+        }
+
+        public Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, Partition partition)
+        {
+            return Task.FromResult(GetTopicProducer(topicIdOrName, partition));
+        }
+
+        public Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, StreamPartitionerDelegate partitioner)
+        {
+            return Task.FromResult(GetTopicProducer(topicIdOrName, partitioner));
         }
     }
 }

--- a/src/QuixStreams.Streaming/KafkaStreamingClient.cs
+++ b/src/QuixStreams.Streaming/KafkaStreamingClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using QuixStreams.Kafka;
 using QuixStreams.Kafka.Transport;
@@ -55,9 +56,17 @@ namespace QuixStreams.Streaming
         /// Gets a topic producer capable of publishing non-quixstreams messages.
         /// </summary>
         /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
-        IRawTopicProducer GetRawTopicProducer(string topic, int partitionId);
+        IRawTopicProducer GetRawTopicProducer(string topic, Partition partition);
+
+        /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitioner">Partitioner to produce messages with.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        IRawTopicProducer GetRawTopicProducer(string topic, QuixPartitionerDelegate partitioner);
 
         /// <summary>
         /// Gets a topic producer capable of publishing stream messages. 
@@ -70,9 +79,17 @@ namespace QuixStreams.Streaming
         /// Gets a topic producer capable of publishing stream messages.
         /// </summary>
         /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
-        ITopicProducer GetTopicProducer(string topic, int partitionId);
+        ITopicProducer GetTopicProducer(string topic, Partition partition);
+        
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        ITopicProducer GetTopicProducer(string topic, StreamPartitionerDelegate partitioner);
     }
 
     /// <summary>
@@ -229,11 +246,26 @@ namespace QuixStreams.Streaming
         /// Gets a topic producer capable of publishing non-quixstreams messages.
         /// </summary>
         /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">Partition to produce messages to.</param>
         /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
-        public IRawTopicProducer GetRawTopicProducer(string topic, int partitionId)
+        public IRawTopicProducer GetRawTopicProducer(string topic, Partition partition)
         {
-            var rawTopicProducer = new RawTopicProducer(brokerAddress, topic, brokerProperties, partitionId);
+            var rawTopicProducer = new RawTopicProducer(brokerAddress, topic, brokerProperties, partition);
+
+            App.Register(rawTopicProducer);
+
+            return rawTopicProducer;
+        }
+        
+        /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitioner">Partitioner to produce messages with.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        public IRawTopicProducer GetRawTopicProducer(string topic, QuixPartitionerDelegate partitioner)
+        {
+            var rawTopicProducer = new RawTopicProducer(brokerAddress, topic, brokerProperties, partitioner);
 
             App.Register(rawTopicProducer);
 
@@ -258,11 +290,26 @@ namespace QuixStreams.Streaming
         /// Gets a topic producer capable of publishing stream messages.
         /// </summary>
         /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
-        public ITopicProducer GetTopicProducer(string topic, int partitionId)
+        public ITopicProducer GetTopicProducer(string topic, Partition partition)
         {
-            var topicProducer = new TopicProducer(new KafkaProducerConfiguration(brokerAddress, brokerProperties), topic, partitionId);
+            var topicProducer = new TopicProducer(new KafkaProducerConfiguration(brokerAddress, brokerProperties), topic, partition);
+
+            App.Register(topicProducer);
+
+            return topicProducer;
+        }
+        
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topic">Name of the topic.</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        public ITopicProducer GetTopicProducer(string topic, StreamPartitionerDelegate partitioner)
+        {
+            var topicProducer = new TopicProducer(new KafkaProducerConfiguration(brokerAddress, brokerProperties), topic, partitioner);
 
             App.Register(topicProducer);
 

--- a/src/QuixStreams.Streaming/QuixStreamingClient.cs
+++ b/src/QuixStreams.Streaming/QuixStreamingClient.cs
@@ -13,6 +13,7 @@ using System.Security.Authentication;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using QuixStreams.Kafka;
@@ -75,10 +76,18 @@ namespace QuixStreams.Streaming
         /// <summary>
         /// Gets a topic producer capable of publishing non-quixstreams messages.
         /// </summary>
-        /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
-        IRawTopicProducer GetRawTopicProducer(string topic, int partitionId);
+        IRawTopicProducer GetRawTopicProducer(string topicIdOrName, Partition partition);
+        
+        /// <summary>
+        /// Gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        IRawTopicProducer GetRawTopicProducer(string topicIdOrName, QuixPartitionerDelegate partitioner);
 
         /// <summary>
         /// Gets a topic producer capable of publishing stream messages.
@@ -90,10 +99,18 @@ namespace QuixStreams.Streaming
         /// <summary>
         /// Gets a topic producer capable of publishing stream messages.
         /// </summary>
-        /// <param name="topic">Name of the topic.</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>Instance of <see cref="ITopicProducer"/></returns>
-        ITopicProducer GetTopicProducer(string topic, int partitionId);
+        ITopicProducer GetTopicProducer(string topicIdOrName, Partition partition);
+        
+        /// <summary>
+        /// Gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+        ITopicProducer GetTopicProducer(string topicIdOrName, StreamPartitionerDelegate partitioner);
     }
 
     /// <summary>
@@ -142,9 +159,17 @@ namespace QuixStreams.Streaming
         /// Asynchronously gets a topic producer capable of publishing non-quixstreams messages.
         /// </summary>
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>A task returning an instance of <see cref="IRawTopicProducer"/></returns>
-        Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, int partitionId);
+        Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, Partition partition);
+        
+        /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing non-quixstreams messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>A task returning an instance of <see cref="IRawTopicProducer"/></returns>
+        Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, QuixPartitionerDelegate partitioner);
 
         /// <summary>
         /// Asynchronously gets a topic producer capable of publishing stream messages.
@@ -157,9 +182,17 @@ namespace QuixStreams.Streaming
         /// Asynchronously gets a topic producer capable of publishing stream messages.
         /// </summary>
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
+        /// <param name="partition">The partition to produce to.</param>
         /// <returns>A task returning an instance of <see cref="ITopicProducer"/></returns>
-        Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, int partitionId);
+        Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, Partition partition);
+        
+        /// <summary>
+        /// Asynchronously gets a topic producer capable of publishing stream messages.
+        /// </summary>
+        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
+        /// <param name="partitioner">The partitioner to produce with.</param>
+        /// <returns>A task returning an instance of <see cref="ITopicProducer"/></returns>
+        Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, StreamPartitionerDelegate partitioner);
     }
 
     /// <summary>
@@ -268,14 +301,7 @@ namespace QuixStreams.Streaming
             }
         }
 
-        /// <summary>
-        /// Gets a topic consumer capable of subscribing to receive incoming streams.
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
-        /// <param name="options">The settings to use for committing</param>
-        /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
-        /// <returns>Instance of <see cref="ITopicConsumer"/></returns>
+        /// <inheritdoc/>
         public ITopicConsumer GetTopicConsumer(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
@@ -286,14 +312,7 @@ namespace QuixStreams.Streaming
             return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset);
         }
 
-        /// <summary>
-        /// Gets a topic consumer capable of subscribing to receive incoming streams.
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="partitionOffset">The partition offset to start reading from</param>
-        /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
-        /// <param name="options">The settings to use for committing</param>
-        /// <returns>Instance of <see cref="ITopicConsumer"/></returns>
+        /// <inheritdoc/>
         public ITopicConsumer GetTopicConsumer(string topicIdOrName, PartitionOffset partitionOffset, string consumerGroup = null, CommitOptions options = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
@@ -326,13 +345,7 @@ namespace QuixStreams.Streaming
             return client.GetTopicConsumer(topicId, partitionOffset, consumerGroup, options);
         }
 
-        /// <summary>
-        /// Gets a topic consumer capable of subscribing to receive non-quixstreams incoming messages. 
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
-        /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
-        /// <returns>Instance of <see cref="IRawTopicConsumer"/></returns>
+        /// <inheritdoc/>
         public IRawTopicConsumer GetRawTopicConsumer(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
@@ -354,11 +367,7 @@ namespace QuixStreams.Streaming
             return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset);
         }
 
-        /// <summary>
-        /// Gets a topic producer capable of publishing non-quixstreams messages. 
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
+        /// <inheritdoc/>
         public IRawTopicProducer GetRawTopicProducer(string topicIdOrName)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
@@ -368,19 +377,24 @@ namespace QuixStreams.Streaming
             return client.GetRawTopicProducer(topicId);
         }
 
-        /// <summary>
-        /// Gets a topic producer capable of publishing non-quixstreams messages.
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
-        /// <returns>Instance of <see cref="IRawTopicProducer"/></returns>
-        public IRawTopicProducer GetRawTopicProducer(string topicIdOrName, int partitionId)
+        /// <inheritdoc/>
+        public IRawTopicProducer GetRawTopicProducer(string topicIdOrName, Partition partition)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
 
-            return client.GetRawTopicProducer(topicId, partitionId);
+            return client.GetRawTopicProducer(topicId, partition);
+        }
+
+        /// <inheritdoc/>
+        public IRawTopicProducer GetRawTopicProducer(string topicIdOrName, QuixPartitionerDelegate partitioner)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            return client.GetRawTopicProducer(topicId, partitioner);
         }
 
         /// <inheritdoc/>
@@ -394,21 +408,26 @@ namespace QuixStreams.Streaming
         }
 
         /// <inheritdoc/>
-        public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, int partitionId)
+        public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, Partition partition)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
 
-            return client.GetRawTopicProducer(topicId, partitionId);
+            return client.GetRawTopicProducer(topicId, partition);
         }
 
+        /// <inheritdoc/>
+        public async Task<IRawTopicProducer> GetRawTopicProducerAsync(string topicIdOrName, QuixPartitionerDelegate partitioner)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
-        /// <summary>
-        /// Gets a topic producer capable of publishing stream messages.
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+
+            return client.GetRawTopicProducer(topicId, partitioner);
+        }
+
+        /// <inheritdoc/>
         public ITopicProducer GetTopicProducer(string topicIdOrName)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
@@ -418,19 +437,24 @@ namespace QuixStreams.Streaming
             return client.GetTopicProducer(topicId);
         }
 
-        /// <summary>
-        /// Gets a topic producer capable of publishing stream messages.
-        /// </summary>
-        /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
-        /// <param name="partitionId">Id of the partition to produce to.</param>
-        /// <returns>Instance of <see cref="ITopicProducer"/></returns>
-        public ITopicProducer GetTopicProducer(string topicIdOrName, int partitionId)
+        /// <inheritdoc/>
+        public ITopicProducer GetTopicProducer(string topicIdOrName, Partition partition)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
 
-            return client.GetTopicProducer(topicId, partitionId);
+            return client.GetTopicProducer(topicId, partition);
+        }
+
+        /// <inheritdoc/>
+        public ITopicProducer GetTopicProducer(string topicIdOrName, StreamPartitionerDelegate partitioner)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
+
+            return client.GetTopicProducer(topicId, partitioner);
         }
 
         /// <inheritdoc/>
@@ -444,13 +468,23 @@ namespace QuixStreams.Streaming
         }
 
         /// <inheritdoc/>
-        public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, int partitionId)
+        public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, Partition partition)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
 
-            return client.GetTopicProducer(topicId, partitionId);
+            return client.GetTopicProducer(topicId, partition);
+        }
+
+        /// <inheritdoc/>
+        public async Task<ITopicProducer> GetTopicProducerAsync(string topicIdOrName, StreamPartitionerDelegate partitioner)
+        {
+            if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
+
+            var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
+
+            return client.GetTopicProducer(topicId, partitioner);
         }
 
         private async Task<(string, CommitOptions)> GetValidConsumerGroup(string topicIdOrName, string originalConsumerGroup, CommitOptions commitOptions)
@@ -892,8 +926,6 @@ namespace QuixStreams.Streaming
                 return await SendRequestToApi(method, uri, bodyModel).ConfigureAwait(false);
             }
         }
-        
-        
 
         private async Task<T> GetModelFromApi<T>(string path, bool saveToCache, bool readFromCache) where T : class
         {

--- a/src/QuixStreams.Streaming/QuixStreamingClient.cs
+++ b/src/QuixStreams.Streaming/QuixStreamingClient.cs
@@ -44,8 +44,9 @@ namespace QuixStreams.Streaming
         /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
         /// <param name="options">The settings to use for committing</param>
         /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <param name="partitions">The partitions to subscribe to. If not provided, All partitions are subscribed to according to other configuration such as consumer group.</param>
         /// <returns>Instance of <see cref="ITopicConsumer"/></returns>
-        ITopicConsumer GetTopicConsumer(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest);
+        ITopicConsumer GetTopicConsumer(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest, ICollection<Partition> partitions = null);
 
         /// <summary>
         /// Gets a topic consumer capable of subscribing to receive incoming streams.
@@ -63,8 +64,9 @@ namespace QuixStreams.Streaming
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
         /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
         /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <param name="partitions">The partitions to subscribe to. If not provided, All partitions are subscribed to according to other configuration such as consumer group.</param>
         /// <returns>Instance of <see cref="IRawTopicConsumer"/></returns>
-        IRawTopicConsumer GetRawTopicConsumer(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null);
+        IRawTopicConsumer GetRawTopicConsumer(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null, ICollection<Partition> partitions = null);
 
         /// <summary>
         /// Gets a topic producer capable of publishing non-quixstreams messages. 
@@ -126,8 +128,9 @@ namespace QuixStreams.Streaming
         /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
         /// <param name="options">The settings to use for committing</param>
         /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <param name="partitions">The partitions to subscribe to. If not provided, All partitions are subscribed to according to other configuration such as consumer group.</param>
         /// <returns>A task returning an instance of <see cref="ITopicConsumer"/></returns>
-        Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest);
+        Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest, ICollection<Partition> partitions = null);
 
         /// <summary>
         /// Asynchronously gets a topic consumer capable of subscribing to receive incoming streams.
@@ -145,8 +148,9 @@ namespace QuixStreams.Streaming
         /// <param name="topicIdOrName">Id or name of the topic. If name is provided, workspace will be derived from environment variable or token, in that order</param>
         /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
         /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
+        /// <param name="partitions">The partitions to subscribe to. If not provided, All partitions are subscribed to according to other configuration such as consumer group.</param>
         /// <returns>A task returning an instance of <see cref="IRawTopicConsumer"/></returns>
-        Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null);
+        Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null, ICollection<Partition> partitions = null);
 
         /// <summary>
         /// Asynchronously gets a topic producer capable of publishing non-quixstreams messages.
@@ -302,14 +306,14 @@ namespace QuixStreams.Streaming
         }
 
         /// <inheritdoc/>
-        public ITopicConsumer GetTopicConsumer(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest)
+        public ITopicConsumer GetTopicConsumer(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest, ICollection<Partition> partitions = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
             
             var (client, topicId, ws) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
             (consumerGroup, options) = GetValidConsumerGroup(topicIdOrName, consumerGroup, options).ConfigureAwait(false).GetAwaiter().GetResult();
             
-            return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset);
+            return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset, partitions);
         }
 
         /// <inheritdoc/>
@@ -322,16 +326,16 @@ namespace QuixStreams.Streaming
             
             return client.GetTopicConsumer(topicId, partitionOffset, consumerGroup, options);
         }
-        
+
         /// <inheritdoc/>
-        public async Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest)
+        public async Task<ITopicConsumer> GetTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, CommitOptions options = null, AutoOffsetReset autoOffset = AutoOffsetReset.Latest, ICollection<Partition> partitions = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, ws) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
             (consumerGroup, options) = await GetValidConsumerGroup(topicIdOrName, consumerGroup, options).ConfigureAwait(false);
 
-            return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset);
+            return client.GetTopicConsumer(topicId, consumerGroup, options, autoOffset, partitions);
         }
 
         /// <inheritdoc/>
@@ -346,25 +350,25 @@ namespace QuixStreams.Streaming
         }
 
         /// <inheritdoc/>
-        public IRawTopicConsumer GetRawTopicConsumer(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null)
+        public IRawTopicConsumer GetRawTopicConsumer(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null, ICollection<Partition> partitions = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false).GetAwaiter().GetResult();
             (consumerGroup, _) = GetValidConsumerGroup(topicIdOrName, consumerGroup, null).ConfigureAwait(false).GetAwaiter().GetResult();
 
-            return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset);
+            return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset, partitions);
         }
 
         /// <inheritdoc/>
-        public async Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null)
+        public async Task<IRawTopicConsumer> GetRawTopicConsumerAsync(string topicIdOrName, string consumerGroup = null, AutoOffsetReset? autoOffset = null, ICollection<Partition> partitions = null)
         {
             if (string.IsNullOrWhiteSpace(topicIdOrName)) throw new ArgumentNullException(nameof(topicIdOrName));
 
             var (client, topicId, _) = await this.ValidateTopicAndCreateClient(topicIdOrName).ConfigureAwait(false);
             (consumerGroup, _) = await GetValidConsumerGroup(topicIdOrName, consumerGroup, null).ConfigureAwait(false);
 
-            return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset);
+            return client.GetRawTopicConsumer(topicId, consumerGroup, autoOffset, partitions);
         }
 
         /// <inheritdoc/>

--- a/src/QuixStreams.Streaming/Raw/RawTopicConsumer.cs
+++ b/src/QuixStreams.Streaming/Raw/RawTopicConsumer.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Confluent.Kafka;
 using Microsoft.Extensions.Logging;
 using QuixStreams.Kafka;
 using QuixStreams;
 using QuixStreams.Kafka.Transport;
 using QuixStreams.Telemetry.Kafka;
+using AutoOffsetReset = QuixStreams.Telemetry.Kafka.AutoOffsetReset;
 
 namespace QuixStreams.Streaming.Raw
 {
@@ -60,7 +62,8 @@ namespace QuixStreams.Streaming.Raw
         /// <param name="consumerGroup">The consumer group id to use for consuming messages. If null, consumer group is not used and only consuming new messages.</param>
         /// <param name="brokerProperties">Additional broker properties</param>
         /// <param name="autoOffset">The offset to use when there is no saved offset for the consumer group.</param>
-        public RawTopicConsumer(string brokerAddress, string topicName, string consumerGroup, Dictionary<string, string> brokerProperties = null, AutoOffsetReset? autoOffset = null)
+        /// <param name="partitions">The partitions to subscribe to. If not provided, All partitions are subscribed to according to other configuration such as consumer group.</param>
+        public RawTopicConsumer(string brokerAddress, string topicName, string consumerGroup, Dictionary<string, string> brokerProperties = null, AutoOffsetReset? autoOffset = null, ICollection<Partition> partitions = null)
         {
             this.topicName = topicName;
             brokerProperties ??= new Dictionary<string, string>();
@@ -76,7 +79,7 @@ namespace QuixStreams.Streaming.Raw
             //disable quix-custom keep alive messages because they can interfere with the received data since we dont have any protocol running this over
             consConfig.CheckForKeepAlivePackets = false;
 
-            var topicConfiguration = new ConsumerTopicConfiguration(topicName);
+            var topicConfiguration = new ConsumerTopicConfiguration(topicName, partitions);
             this.kafkaConsumer = new KafkaConsumer(consConfig, topicConfiguration);
         }
 

--- a/src/QuixStreams.Streaming/Raw/RawTopicProducer.cs
+++ b/src/QuixStreams.Streaming/Raw/RawTopicProducer.cs
@@ -38,18 +38,37 @@ namespace QuixStreams.Streaming.Raw
         /// <param name="partition">Partition to produce to.</param>
         /// <param name="brokerProperties">Additional broker properties</param>
         public RawTopicProducer(string brokerAddress, string topicName, Dictionary<string, string> brokerProperties, Partition partition)
+            : this(brokerAddress, topicName, brokerProperties, partition, null)
+        {
+        }
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="RawTopicProducer"/>
+        /// </summary>
+        /// <param name="brokerAddress">Address of Kafka cluster.</param>
+        /// <param name="topicName">Name of the topic.</param>
+        /// <param name="partitioner">Partitioner to produce each message with.</param>
+        /// <param name="brokerProperties">Additional broker properties</param>
+        public RawTopicProducer(string brokerAddress, string topicName, Dictionary<string, string> brokerProperties, QuixPartitionerDelegate partitioner)
+            : this(brokerAddress, topicName, brokerProperties, Partition.Any, partitioner)
+        {
+        }
+        
+        private RawTopicProducer(string brokerAddress, string topicName, Dictionary<string, string> brokerProperties, Partition partition, QuixPartitionerDelegate partitioner)
         {
             brokerProperties ??= new Dictionary<string, string>();
             if (!brokerProperties.ContainsKey("queued.max.messages.kbytes")) brokerProperties["queued.max.messages.kbytes"] = "20480";
 
             this.topicName = topicName;
 
-            var publisherConfiguration = new QuixStreams.Kafka.ProducerConfiguration(brokerAddress, brokerProperties);
-            var topicConfiguration = new QuixStreams.Kafka.ProducerTopicConfiguration(this.topicName, partition);
+            var publisherConfiguration = new ProducerConfiguration(brokerAddress, brokerProperties);
+            var topicConfiguration = partitioner == null
+                ? new ProducerTopicConfiguration(this.topicName, partition)
+                : new ProducerTopicConfiguration(this.topicName, partitioner);
 
             this.kafkaProducer = new KafkaProducer(publisherConfiguration, topicConfiguration);
         }
-
+        
         /// <summary>
         /// Initializes a new instance of <see cref="RawTopicProducer"/>
         /// </summary>

--- a/src/QuixStreams.Streaming/StreamConsumer.cs
+++ b/src/QuixStreams.Streaming/StreamConsumer.cs
@@ -138,9 +138,7 @@ namespace QuixStreams.Streaming
                 };
 
                 this.OnEventData?.Invoke(this, ev);
-                return;
             }
-
 
             this.logger.LogTrace("StreamConsumer: OnStreamPackageReceived");
             this.OnPackageReceived?.Invoke(this, new PackageReceivedEventArgs(this.topicConsumer, this, package));

--- a/src/QuixStreams.Streaming/StreamProducer.cs
+++ b/src/QuixStreams.Streaming/StreamProducer.cs
@@ -280,7 +280,7 @@ namespace QuixStreams.Streaming
                     sw.Stop();
                     if (!lastSendTask.IsCanceled && !lastSendTask.IsCompleted && !lastSendTask.IsFaulted)
                     {
-                        this.logger.LogWarning("Last send did not finish in {0:g} for stream {1}. In future this timeout will be configurable.", sw.Elapsed, this.StreamId);
+                        this.logger.LogWarning("Last send did not finish in {0:g} for stream {1}.", sw.Elapsed, this.StreamId);
                     }
                     else
                     {


### PR DESCRIPTION
- Introduce Partitioner for Raw and non-raw topic producer
- Replace int partitionId with struct Partition
- Add Multiple partition support to raw and non-raw topic consumers
- Improve on consumer connection detection to avoid unnecessary wait times