### PR TITLE
Fix KafkaMessageBuffer purging with incorrect id

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -6,9 +6,9 @@ import shutil
 import fileinput
 from typing import List
 
-version = "0.7.0.0"
-informal_version = "0.7.0.0"
-nuget_version = "0.7.0.0"
+version = "0.7.1.0"
+informal_version = "0.7.1.0-dev1"
+nuget_version = "0.7.1.0-dev1"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMergerHelper.cs
+++ b/src/QuixStreams.Kafka.Transport/SerDes/KafkaMessageMergerHelper.cs
@@ -27,7 +27,7 @@ namespace QuixStreams.Kafka.Transport.SerDes
             this.logger = logger ?? NullLogger.Instance;
             this.buffer.OnMessagePurged += (ea) =>
             {
-                this.OnMessageSegmentsPurged?.Invoke(ea.BufferId);
+                this.OnMessageSegmentsPurged?.Invoke(ea.BufferIds);
             };
         }
 
@@ -69,7 +69,10 @@ namespace QuixStreams.Kafka.Transport.SerDes
                 return MessageMergeResult.Unmerged;
             }
 
-            var messageId = Convert.ToBase64String(messageIdBytes); // Whether it is guid or not, doesn't matter, uniqueness matters
+            
+            var messageId = messageIdBytes.Length == 4 
+                ? BitConverter.ToInt16(messageIdBytes, 0).ToString() 
+                : Convert.ToBase64String(messageIdBytes); // Whether it is guid or not, doesn't matter, uniqueness matters
             var messageIndex = BitConverter.ToInt32(messageIndexBytes, 0);
             var messageCount = BitConverter.ToInt32(messageCountBytes, 0);
 
@@ -137,7 +140,7 @@ namespace QuixStreams.Kafka.Transport.SerDes
         }
 
         /// <inheritdoc />
-        public event Action<MergerBufferId> OnMessageSegmentsPurged;
+        public event Action<ICollection<MergerBufferId>> OnMessageSegmentsPurged;
 
         private MergedKafkaMessage AssembleMessage(MergerBufferId bufferId, ref MergerBufferId messageGroupId)
         {

--- a/src/QuixStreams.Kafka/KafkaMessage.cs
+++ b/src/QuixStreams.Kafka/KafkaMessage.cs
@@ -31,12 +31,12 @@ namespace QuixStreams.Kafka
         protected internal Headers ConfluentHeaders { get; protected set; }
         
         /// <summary>
-        /// The estimated message size including header, key, value
+        /// The estimated message size in bytes including header, key, value
         /// </summary>
         public int MessageSize { get; protected set; }
         
         /// <summary>
-        /// The estimated (worst case) size of the message headers
+        /// The estimated (worst case) size of the message headers in bytes
         /// </summary>
         public int HeaderSize { get; protected set; }
         


### PR DESCRIPTION
KafkaMessageBuffer incorrectly used the id of the message being added rather than the one being kicked when there was no more space for concurrent split messages.

Also added minor improvements so can purge multiple items at the same time.

Using short for messageId in Merger as 4 byte ids are legacy and mean a short. Improves debuggability.
