### PR TITLE
Less verbose delivery handler and decreased producer queue

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.7.1.0"
-informal_version = "0.7.1.0-dev1"
-nuget_version = "0.7.1.0-dev1"
+informal_version = "0.7.1.0-dev2"
+nuget_version = "0.7.1.0-dev2"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka/ProducerConfiguration.cs
+++ b/src/QuixStreams.Kafka/ProducerConfiguration.cs
@@ -36,7 +36,7 @@ namespace QuixStreams.Kafka
 
         /// <summary>
         /// Maximum total message size sum allowed on the queue. This property has higher priority than <see cref="QueueBufferingMaxMessages" />
-        /// default: 1048576
+        /// default: 103424 (101MB)
         /// </summary>
         public int? QueueBufferingMaxKbytes { get; set; }
 
@@ -112,6 +112,11 @@ namespace QuixStreams.Kafka
             if (!producerProperties.ContainsKey("log_level"))
             {
                 producerProperties["log_level"] = "0";
+            }
+
+            if (!producerProperties.ContainsKey("queue.buffering.max.kbytes") && !QueueBufferingMaxKbytes.HasValue)
+            {
+                QueueBufferingMaxKbytes = 103424;
             }
 
             var config = new ProducerConfig(producerProperties);


### PR DESCRIPTION
Converted the delivery handler to no longer return the original key, value etc to reduce memory footprint.

Reduced the max queued message size to 101 MB from 1GB when none specified.