### PR TITLE
Multi-Targets projects for target framework compatibility with Microsoft.Extensions.Logging

### DIFF
--- a/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
+++ b/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
@@ -20,19 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Serilog" Version="2.12.0" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\QuixStreams.Kafka\QuixStreams.Kafka.csproj" />
   </ItemGroup>
-
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
+++ b/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Configurations>Debug;Release</Configurations>
-    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
+++ b/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
@@ -4,7 +4,7 @@
     <DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
@@ -23,13 +23,23 @@
 
   <ItemGroup>
     <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/QuixStreams.State/QuixStreams.State.csproj
@@ -4,7 +4,7 @@
 		<DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
 		<Configurations>Debug;Release</Configurations>
 		<Platforms>AnyCPU</Platforms>
-		<TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
 		<LangVersion>9.0</LangVersion>
 	</PropertyGroup>
 
@@ -28,10 +28,21 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 		<PackageReference Include="RocksDB" Version="8.3.2.39829" />
 	</ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/QuixStreams.State/QuixStreams.State.csproj
+++ b/src/QuixStreams.State/QuixStreams.State.csproj
@@ -1,37 +1,37 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-		<Configurations>Debug;Release</Configurations>
-		<Platforms>AnyCPU</Platforms>
+  <PropertyGroup>
+    <DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Configurations>Debug;Release</Configurations>
+    <Platforms>AnyCPU</Platforms>
     <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
-		<LangVersion>9.0</LangVersion>
-	</PropertyGroup>
+    <LangVersion>9.0</LangVersion>
+  </PropertyGroup>
 
-	<PropertyGroup>
-		<PackageId>QuixStreams.State</PackageId>
-		<Version>0.7.0.0</Version>
-		<AssemblyVersion>0.7.0.0</AssemblyVersion>
-		<FileVersion>0.7.0.0</FileVersion>
-		<InformationalVersion>0.7.0.0</InformationalVersion>
-		<Company>Quix Analytics Ltd</Company>
-		<Authors>devs@quix.io</Authors>
-		<Product>QuixStreams.State</Product>
-		<Description>State abstraction and implementation for Quix Streams</Description>
-		<Copyright>Copyright © Quix Analytics Ltd 2020</Copyright>
-	</PropertyGroup>
+  <PropertyGroup>
+    <PackageId>QuixStreams.State</PackageId>
+    <Version>0.7.0.0</Version>
+    <AssemblyVersion>0.7.0.0</AssemblyVersion>
+    <FileVersion>0.7.0.0</FileVersion>
+    <InformationalVersion>0.7.0.0</InformationalVersion>
+    <Company>Quix Analytics Ltd</Company>
+    <Authors>devs@quix.io</Authors>
+    <Product>QuixStreams.State</Product>
+    <Description>State abstraction and implementation for Quix Streams</Description>
+    <Copyright>Copyright © Quix Analytics Ltd 2020</Copyright>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-			<_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
-		</AssemblyAttribute>
-	</ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DynamicProxyGenAssembly2</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-		<PackageReference Include="RocksDB" Version="8.3.2.39829" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+    <PackageReference Include="RocksDB" Version="8.3.2.39829" />
+  </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />

--- a/src/QuixStreams.Streaming/QuixStreams.Streaming.csproj
+++ b/src/QuixStreams.Streaming/QuixStreams.Streaming.csproj
@@ -5,8 +5,7 @@
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
     <LangVersion>8.0</LangVersion>
-
-    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/QuixStreams.Telemetry/QuixStreams.Telemetry.csproj
+++ b/src/QuixStreams.Telemetry/QuixStreams.Telemetry.csproj
@@ -4,8 +4,7 @@
     <DocumentationFile>bin\$(OutputDir)\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-
-    <TargetFrameworks>net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change multi-targets the release packages so that when consuming from different .net versions, the appropriate version of the Microsoft.Extensions.Logging libraries are loaded. This fixes an issue I had initialising Quix libraries in a .net6-windows application, where v7.0.0 of the MS logging libraries could not be loaded at runtime.