### PR TITLE
Remove unused references and fix CVE-2024-21319

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.7.3.0"
-informal_version = "0.7.3.0-dev1"
-nuget_version = "0.7.3.0-dev1"
+informal_version = "0.7.3.0-dev2"
+nuget_version = "0.7.3.0-dev2"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka.Tests/QuixStreams.Kafka.Tests.csproj
+++ b/src/QuixStreams.Kafka.Tests/QuixStreams.Kafka.Tests.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="xunit" Version="2.4.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
         <PackageReference Include="coverlet.collector" Version="1.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
+++ b/src/QuixStreams.Kafka.Transport/QuixStreams.Kafka.Transport.csproj
@@ -29,4 +29,8 @@
     </AssemblyAttribute>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
+++ b/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
@@ -27,7 +27,6 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
+++ b/src/QuixStreams.State.UnitTests/QuixStreams.State.UnitTests.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/src/QuixStreams.Streaming.IntegrationTests/QuixStreams.Streaming.IntegrationTests.csproj
+++ b/src/QuixStreams.Streaming.IntegrationTests/QuixStreams.Streaming.IntegrationTests.csproj
@@ -8,12 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Ductus.FluentDocker" Version="2.10.57" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QuixStreams.Streaming/QuixStreams.Streaming.csproj
+++ b/src/QuixStreams.Streaming/QuixStreams.Streaming.csproj
@@ -43,7 +43,6 @@
   <ItemGroup>
     <PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.2" />
     <PackageReference Include="System.Runtime.Caching" Version="7.0.0" />
   </ItemGroup>
 

--- a/src/QuixStreams.Telemetry/QuixStreams.Telemetry.csproj
+++ b/src/QuixStreams.Telemetry/QuixStreams.Telemetry.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.22.1" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Remove JWT lib instead of upgrade as only used for rare scenarios as warning. 
- Remove unused references