### PR TITLE
Fix committed offset always lagging behind 1

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.7.3.0"
-informal_version = "0.7.3.0-dev2"
-nuget_version = "0.7.3.0-dev2"
+informal_version = "0.7.3.0-dev3"
+nuget_version = "0.7.3.0-dev3"
 
 
 def updatecsproj(projfilepath):

--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.7.3.0"
-informal_version = "0.7.3.0-dev3"
-nuget_version = "0.7.3.0-dev3"
+informal_version = "0.7.3.0-dev4"
+nuget_version = "0.7.3.0-dev4"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Kafka.Transport/TransportKafkaConsumer.cs
+++ b/src/QuixStreams.Kafka.Transport/TransportKafkaConsumer.cs
@@ -98,14 +98,14 @@ namespace QuixStreams.Kafka.Transport
             if (options.CommitOptions?.AutoCommitEnabled ?? false)
             {
                 var commitModifier = new AutoCommitter(options.CommitOptions, this.kafkaConsumer.Commit);
-                merger.OnMessageAvailable += message =>
+                merger.OnMessageAvailable = message =>
                 {
                     var package = deserializer.Deserialize(message);
                     return commitModifier.Publish(package);
                 };
                 closeAction = () => commitModifier.Close();
 
-                commitModifier.OnPackageAvailable += package => this.OnPackageReceived?.Invoke(package) ?? Task.CompletedTask;
+                commitModifier.OnPackageAvailable = package => this.OnPackageReceived?.Invoke(package) ?? Task.CompletedTask;
 
                 kafkaConsumer.OnRevoked += (sender, args) =>
                 {
@@ -158,7 +158,7 @@ namespace QuixStreams.Kafka.Transport
             }
             else
             {
-                merger.OnMessageAvailable += message =>
+                merger.OnMessageAvailable = message =>
                 {
                     var package = deserializer.Deserialize(message);
                     return this.OnPackageReceived?.Invoke(package) ?? Task.CompletedTask;

--- a/src/QuixStreams.Kafka.Transport/TransportKafkaConsumer.cs
+++ b/src/QuixStreams.Kafka.Transport/TransportKafkaConsumer.cs
@@ -105,7 +105,7 @@ namespace QuixStreams.Kafka.Transport
                 };
                 closeAction = () => commitModifier.Close();
 
-                commitModifier.OnPackageAvailable += package => this.OnPackageReceived?.Invoke(package);
+                commitModifier.OnPackageAvailable += package => this.OnPackageReceived?.Invoke(package) ?? Task.CompletedTask;
 
                 kafkaConsumer.OnRevoked += (sender, args) =>
                 {
@@ -161,7 +161,7 @@ namespace QuixStreams.Kafka.Transport
                 merger.OnMessageAvailable += message =>
                 {
                     var package = deserializer.Deserialize(message);
-                    return this.OnPackageReceived?.Invoke(package);
+                    return this.OnPackageReceived?.Invoke(package) ?? Task.CompletedTask;
                 };
                 
                 kafkaConsumer.OnCommitted += (sender, args) =>

--- a/src/QuixStreams.Kafka/ConsumerConfiguration.cs
+++ b/src/QuixStreams.Kafka/ConsumerConfiguration.cs
@@ -16,7 +16,7 @@ namespace QuixStreams.Kafka
         /// <param name="brokerList">The list of brokers as a comma separated list of broker host or host:port.</param>
         /// <param name="groupId">Client group id string. All clients sharing the same GroupId belong to the same group.</param>
         /// <param name="consumerProperties">List of broker and consumer kafka properties that overrides the default configuration values.</param>
-        public ConsumerConfiguration(string brokerList, string groupId = null, IDictionary<string, string> consumerProperties = null)
+        public ConsumerConfiguration(string brokerList, string? groupId = null, IDictionary<string, string>? consumerProperties = null)
         {
             if (string.IsNullOrWhiteSpace(brokerList))
             {
@@ -48,7 +48,7 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// Client group id string. All clients sharing the same GroupId belong to the same group.
         /// </summary>
-        public string GroupId { get; }
+        public string? GroupId { get; }
 
         /// <summary>
         /// Whether the consumer group is set

--- a/src/QuixStreams.Kafka/IKafkaConsumer.cs
+++ b/src/QuixStreams.Kafka/IKafkaConsumer.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Confluent.Kafka;

--- a/src/QuixStreams.Kafka/KafkaConsumer.cs
+++ b/src/QuixStreams.Kafka/KafkaConsumer.cs
@@ -912,6 +912,7 @@ namespace QuixStreams.Kafka
                     Debug.Assert(this.consumerTopicConfiguration.Partitions != null, "Partitions must not be null");
                     invalidTopics = partitionOffsets.Where(x => this.consumerTopicConfiguration.Partitions.All(y => y.TopicPartition != x.TopicPartition)).Select(x => x.Topic).Distinct().ToList();
                 }
+                
                 if (invalidTopics.Count > 0)
                 {
                     if (invalidTopics.Count == 0) throw new InvalidOperationException($"[{this.configId}] Topic {invalidTopics[0]} offset cannot be committed because topic is not subscribed to.");

--- a/src/QuixStreams.Kafka/KafkaConsumer.cs
+++ b/src/QuixStreams.Kafka/KafkaConsumer.cs
@@ -933,7 +933,9 @@ namespace QuixStreams.Kafka
                 try
                 {
                     this.OnCommitting?.Invoke(this, new CommittingEventArgs(latestPartitionOffsets));
-                    this.consumer.Commit(latestPartitionOffsets);
+                    // When committing to kafka, one has to commit with one higher offset, see https://github.com/confluentinc/confluent-kafka-dotnet/blob/d5d85ea862581381fb318cdcff29e61a5cc72f8d/src/Confluent.Kafka/Consumer.cs#L459
+                    var offsets = latestPartitionOffsets.Select(y => new TopicPartitionOffset(y.TopicPartition, y.Offset + 1)).ToList();
+                    this.consumer.Commit(offsets);
                     this.OnCommitted?.Invoke(this, new CommittedEventArgs(GetCommittedOffsets(latestPartitionOffsets, null)));
                 }
                 catch (TopicPartitionOffsetException ex)

--- a/src/QuixStreams.Kafka/KafkaConsumer.cs
+++ b/src/QuixStreams.Kafka/KafkaConsumer.cs
@@ -880,8 +880,6 @@ namespace QuixStreams.Kafka
             }
         }
         
-        
-        
         /// <inheritdoc/>
         public void Commit(ICollection<TopicPartitionOffset> partitionOffsets)
         {

--- a/src/QuixStreams.Kafka/KafkaHelper.cs
+++ b/src/QuixStreams.Kafka/KafkaHelper.cs
@@ -11,8 +11,8 @@ namespace QuixStreams.Kafka
         
         public static bool TryParseBrokerNameChange(LogMessage logMessage, out string oldName, out string newName)
         {
-            oldName = null;
-            newName = null;
+            oldName = string.Empty;
+            newName = string.Empty;
             try
             {
                 // UPDATE [thrd:127.0.0.1:9092/bootstrap]: 127.0.0.1:9092/0: Name changed from 127.0.0.1:9092/bootstrap to 127.0.0.1:9092/0
@@ -35,8 +35,8 @@ namespace QuixStreams.Kafka
 
         public static bool TryParseBrokerState(LogMessage logMessage, out string broker, out string state)
         {
-            broker = null;
-            state = null;
+            broker = string.Empty;
+            state = string.Empty;
             try
             {
                 // Example:  Debug [thrd:sasl_ssl://IP:PORT/BROKERID]: sasl_ssl://IP:PORT/BROKERID: Broker changed state DOWN -> INIT

--- a/src/QuixStreams.Kafka/KafkaMessage.cs
+++ b/src/QuixStreams.Kafka/KafkaMessage.cs
@@ -13,7 +13,7 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// The key of the message. Can be null.
         /// </summary>
-        public byte[] Key { get; protected set; }
+        public byte[]? Key { get; protected set; }
         
         /// <summary>
         /// The value of the message.
@@ -23,12 +23,12 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// The headers of the message. Can be null.
         /// </summary>
-        public KafkaHeader[] Headers { get; protected set; }
+        public KafkaHeader[]? Headers { get; protected set; }
 
         /// <summary>
         /// Confluent kafka headers
         /// </summary>
-        protected internal Headers ConfluentHeaders { get; protected set; }
+        protected internal Headers? ConfluentHeaders { get; protected set; }
         
         /// <summary>
         /// The estimated message size in bytes including header, key, value
@@ -43,7 +43,7 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// The topic partition offset associated with the message. Null when the message is not read from broker.
         /// </summary>
-        public TopicPartitionOffset TopicPartitionOffset { get; protected set; }
+        public TopicPartitionOffset? TopicPartitionOffset { get; protected set; }
         
         /// <summary>
         /// The message time
@@ -58,7 +58,7 @@ namespace QuixStreams.Kafka
         /// <param name="headers">The headers of the message. Specify null for no </param>
         /// <param name="timestamp">The optional message time. Defaults to utc now</param>
         /// <param name="topicPartitionOffset">The topic and partition with the specified offset this message is representing</param>
-        public KafkaMessage(byte[] key, byte[] value, KafkaHeader[] headers = null, Timestamp? timestamp = null, TopicPartitionOffset topicPartitionOffset = null)
+        public KafkaMessage(byte[] key, byte[] value, KafkaHeader[]? headers = null, Timestamp? timestamp = null, TopicPartitionOffset? topicPartitionOffset = null)
         {
             Key = key;
             MessageSize += key?.Length ?? 0;
@@ -86,7 +86,7 @@ namespace QuixStreams.Kafka
             TopicPartitionOffset = topicPartitionOffset;
         }
         
-        internal KafkaMessage(ConsumeResult<byte[], byte[]> consumeResult)
+        internal KafkaMessage(ConsumeResult<byte[]?, byte[]> consumeResult)
         {
             
             Key = consumeResult.Message.Key;

--- a/src/QuixStreams.Kafka/ProducerConfiguration.cs
+++ b/src/QuixStreams.Kafka/ProducerConfiguration.cs
@@ -14,7 +14,7 @@ namespace QuixStreams.Kafka
         /// </summary>
         /// <param name="brokerList">The list of brokers as a comma separated list of broker host or host:port.</param>
         /// <param name="producerProperties">List of broker and producer kafka properties that overrides the default configuration values.</param>
-        public ProducerConfiguration(string brokerList, IDictionary<string, string> producerProperties = null)
+        public ProducerConfiguration(string brokerList, IDictionary<string, string>? producerProperties = null)
         {
             if (string.IsNullOrWhiteSpace(brokerList))
                 throw new ArgumentOutOfRangeException(nameof(brokerList), "Cannot be null or empty");

--- a/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
+++ b/src/QuixStreams.Kafka/QuixStreams.Kafka.csproj
@@ -6,6 +6,8 @@
     <Platforms>AnyCPU</Platforms>
     <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>Nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/QuixStreams.Kafka/TopicConfiguration.cs
+++ b/src/QuixStreams.Kafka/TopicConfiguration.cs
@@ -58,7 +58,7 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// The partition to select the partition for the message
         /// </summary>
-        public QuixPartitionerDelegate Partitioner { get; }
+        public QuixPartitionerDelegate? Partitioner { get; }
     }
 
     public sealed class ConsumerTopicConfiguration
@@ -206,12 +206,12 @@ namespace QuixStreams.Kafka
         /// <summary>
         /// The topics
         /// </summary>
-        public IReadOnlyCollection<string> Topics { get; }
+        public IReadOnlyCollection<string>? Topics { get; }
 
         /// <summary>
         /// The topics with partition offsets
         /// </summary>
-        public IReadOnlyCollection<TopicPartitionOffset> Partitions { get; }
+        public IReadOnlyCollection<TopicPartitionOffset>? Partitions { get; }
     }
 
     /// <summary>

--- a/src/QuixStreams.Streaming.IntegrationTests/KafkaStreamingClientIntegrationTests.cs
+++ b/src/QuixStreams.Streaming.IntegrationTests/KafkaStreamingClientIntegrationTests.cs
@@ -798,7 +798,7 @@ namespace QuixStreams.Streaming.IntegrationTests
             }
 
             messagesRead.First().KafkaMessage.TopicPartitionOffset.Offset.Value.Should().Be(0);
-            messagesRead.Last().KafkaMessage.TopicPartitionOffset.Offset.Value.Should().Be(30);
+            messagesRead.Last().KafkaMessage.TopicPartitionOffset.Offset.Value.Should().Be(29);
         }
         
         [Fact]


### PR DESCRIPTION
- Offset committed now always commits 1 ahead, similarly to how Confluent .Net lib does it, or when librdkafa auto commit is enabled
- QuixStreams.Kafka solution marked Nullable to find and fix possible null issues
- Where event was previously refactored to function/action, only use assignment rather than +=