### PR TITLE
Allow setters for event and param definitions

### DIFF
--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -7,8 +7,8 @@ import fileinput
 from typing import List
 
 version = "0.7.4.0"
-informal_version = "0.7.4.0-dev1"
-nuget_version = "0.7.4.0-dev1"
+informal_version = "0.7.4.0"
+nuget_version = "0.7.4.0"
 
 
 def updatecsproj(projfilepath):

--- a/builds/csharp/nuget/build_nugets.py
+++ b/builds/csharp/nuget/build_nugets.py
@@ -6,9 +6,9 @@ import shutil
 import fileinput
 from typing import List
 
-version = "0.7.3.0"
-informal_version = "0.7.3.0"
-nuget_version = "0.7.3.0"
+version = "0.7.4.0"
+informal_version = "0.7.4.0-dev1"
+nuget_version = "0.7.4.0-dev1"
 
 
 def updatecsproj(projfilepath):

--- a/src/QuixStreams.Streaming/Models/EventDefinition.cs
+++ b/src/QuixStreams.Streaming/Models/EventDefinition.cs
@@ -11,33 +11,33 @@ namespace QuixStreams.Streaming.Models
         /// <summary>
         /// Gets the globally unique identifier of the event.
         /// </summary>
-        public string Id { get; internal set;  }
+        public string Id { get; set;  }
 
         /// <summary>
         /// Gets the display name of the event
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets the description of the event
         /// </summary>
-        public string Description { get; internal set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets the location of the event within the Event hierarchy. Example: "/", "car/chassis/suspension".
         /// </summary>
-        public string Location { get; internal set; }
+        public string Location { get; set; }
 
         /// <summary>
         /// Gets the optional field for any custom properties that do not exist on the event.
         /// For example this could be a json string, describing all possible event values
         /// </summary>
-        public string CustomProperties { get; internal set; }
+        public string CustomProperties { get; set; }
 
         /// <summary>
         /// Gets the level of the event. Defaults to <see cref="Telemetry.Models.EventLevel.Information"/>
         /// </summary>
-        public EventLevel Level { get; internal set; } = EventLevel.Information;
+        public EventLevel Level { get; set; } = EventLevel.Information;
 
         /// <summary>
         /// Converts the Event definition to Telemetry layer structure

--- a/src/QuixStreams.Streaming/Models/ParameterDefinition.cs
+++ b/src/QuixStreams.Streaming/Models/ParameterDefinition.cs
@@ -9,48 +9,48 @@
         /// <summary>
         /// Gets the unique parameter id
         /// </summary>
-        public string Id { get; internal set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Gets the human friendly display name of the parameter
         /// </summary>
-        public string Name { get; internal set; }
+        public string Name { get; set; }
 
         /// <summary>
         /// Gets the description of the parameter
         /// </summary>
-        public string Description { get; internal set; }
+        public string Description { get; set; }
 
         /// <summary>
         /// Gets the location of the parameter within the Parameter hierarchy. Example: "/", "car/chassis/suspension".
         /// </summary>
-        public string Location { get; internal set; }
+        public string Location { get; set; }
 
         /// <summary>
         /// Gets the minimum value of the parameter
         /// </summary>
-        public double? MinimumValue { get; internal set; }
+        public double? MinimumValue { get; set; }
         
         /// <summary>
         /// Gets the maximum value of the parameter
         /// </summary>
-        public double? MaximumValue { get; internal set; }
+        public double? MaximumValue { get; set; }
 
         /// <summary>
         /// Gets the unit of the parameter 
         /// </summary>
-        public string Unit { get;internal set; }
+        public string Unit { get;set; }
 
         /// <summary>
         /// Gets the formatting to apply on the value for display purposes
         /// </summary>
-        public string Format { get; internal set; }
+        public string Format { get; set; }
 
         /// <summary>
         /// Gets the optional field for any custom properties that do not exist on the parameter.
         /// For example this could be a json string, describing the optimal value range of this parameter
         /// </summary>
-        public string CustomProperties { get; internal set; }
+        public string CustomProperties { get; set; }
 
         /// <summary>
         /// Converts the Parameter definition to Telemetry layer structure


### PR DESCRIPTION
Enable public setters for the models to allow easier ser/des of the classes